### PR TITLE
Initial MicroSerial core and GUI scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/build/
+/target/
+**/CMakeFiles/
+**/CMakeCache.txt
+**/cmake_install.cmake
+**/Makefile
+**/*.o

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # MicroSerial
-A modern, fast and scalable serial terminal for linux and macOS in C language. 
+
+MicroSerial is a high-performance serial terminal stack that combines a hardened C11 core with a polished Rust GUI. It delivers deterministic low-latency I/O, plugin-ready extensibility, and a delightful operator experience on Linux and macOS.
+
+## Repository Layout
+
+```
+core/      # C core: async serial engine, ring buffers, OS shims
+gui/       # Rust/egui desktop application with FFI wrappers
+plugins/   # Future protocol/decoder plugins (stable C ABI)
+docs/      # Architecture, build guides, roadmap, threat model
+scripts/   # Build helpers
+tests/     # Integration & fuzz harness entrypoints
+```
+
+## Quick Start
+
+1. **Build everything:** `./scripts/build_all.sh`
+2. **Run core tests:**
+   ```
+   cmake -S core -B build/core
+   cmake --build build/core
+   ctest --test-dir build/core
+   ```
+3. **Launch the GUI:** `cargo run --manifest-path gui/Cargo.toml`
+
+The GUI auto-discovers serial ports, opens a dedicated async session, and renders RX/TX streams in real time. For loopback demos without hardware, pair pseudo-terminals with `socat` or rely on the built-in integration test.
+
+## Documentation
+
+* [Design Document](docs/design.md)
+* [Build Guide](docs/build.md)
+* [Roadmap](docs/roadmap.md)
+
+## License
+
+Licensed under the MIT License. See [LICENSE](LICENSE).

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.18)
+project(microserial_core C)
+
+option(MICROSERIAL_ENABLE_ASAN "Enable AddressSanitizer" OFF)
+option(MICROSERIAL_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror=vla -fstack-protector-strong)
+    add_compile_definitions(_FORTIFY_SOURCE=2)
+    if(MICROSERIAL_ENABLE_ASAN)
+        add_compile_options(-fsanitize=address)
+        link_libraries(-fsanitize=address)
+    endif()
+    if(MICROSERIAL_ENABLE_UBSAN)
+        add_compile_options(-fsanitize=undefined)
+        link_libraries(-fsanitize=undefined)
+    endif()
+endif()
+
+set(CORE_HEADERS
+    include/MicroSerial/ms_core.h
+    include/MicroSerial/io/serial.h
+    include/MicroSerial/io/serial_config.h
+    include/MicroSerial/io/serial_discovery.h
+    include/MicroSerial/io/ring_buffer.h
+    include/MicroSerial/util/logging.h
+    include/MicroSerial/util/time.h
+    include/MicroSerial/os/event_loop.h
+    include/MicroSerial/functions/ms_serial_port_open.h
+    include/MicroSerial/functions/ms_serial_port_configure.h
+    include/MicroSerial/functions/ms_serial_port_start.h
+    include/MicroSerial/functions/ms_serial_port_write.h
+    include/MicroSerial/functions/ms_serial_port_close.h
+    include/MicroSerial/functions/ms_serial_port_poll.h
+    include/MicroSerial/functions/ms_serial_port_enumerate.h
+    include/MicroSerial/functions/ms_serial_port_list_free.h
+    include/MicroSerial/functions/ms_ring_buffer_init.h
+    include/MicroSerial/functions/ms_ring_buffer_free.h
+    include/MicroSerial/functions/ms_ring_buffer_write.h
+    include/MicroSerial/functions/ms_ring_buffer_read.h
+    include/MicroSerial/functions/ms_ring_buffer_size.h
+    include/MicroSerial/functions/ms_log_set_level.h
+    include/MicroSerial/functions/ms_log_message.h
+    include/MicroSerial/plugins/plugin_abi.h
+)
+
+set(CORE_SOURCES
+    src/io/serial_port.c
+    src/io/serial_event_loop.c
+    src/util/ring_buffer.c
+    src/util/logging.c
+    src/util/time.c
+    src/os/posix_serial.c
+    src/os/port_enumeration.c
+)
+
+add_library(microserial_core STATIC ${CORE_SOURCES} ${CORE_HEADERS})
+target_include_directories(microserial_core
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(microserial_core PUBLIC pthread)
+
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/core/include/MicroSerial/functions/ms_log_message.h
+++ b/core/include/MicroSerial/functions/ms_log_message.h
@@ -1,0 +1,17 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_LOG_MESSAGE_H
+#define MICROSERIAL_FUNCTIONS_MS_LOG_MESSAGE_H
+
+#include <stdarg.h>
+#include "MicroSerial/functions/ms_log_set_level.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ms_log_message(ms_log_level_t level, const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_LOG_MESSAGE_H */

--- a/core/include/MicroSerial/functions/ms_log_set_level.h
+++ b/core/include/MicroSerial/functions/ms_log_set_level.h
@@ -1,0 +1,22 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_LOG_SET_LEVEL_H
+#define MICROSERIAL_FUNCTIONS_MS_LOG_SET_LEVEL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum ms_log_level {
+    MS_LOG_LEVEL_ERROR = 0,
+    MS_LOG_LEVEL_WARN,
+    MS_LOG_LEVEL_INFO,
+    MS_LOG_LEVEL_DEBUG,
+    MS_LOG_LEVEL_TRACE
+} ms_log_level_t;
+
+void ms_log_set_level(ms_log_level_t level);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_LOG_SET_LEVEL_H */

--- a/core/include/MicroSerial/functions/ms_ring_buffer_free.h
+++ b/core/include/MicroSerial/functions/ms_ring_buffer_free.h
@@ -1,0 +1,16 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_FREE_H
+#define MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_FREE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ms_ring_buffer ms_ring_buffer_t;
+
+void ms_ring_buffer_free(ms_ring_buffer_t *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_FREE_H */

--- a/core/include/MicroSerial/functions/ms_ring_buffer_init.h
+++ b/core/include/MicroSerial/functions/ms_ring_buffer_init.h
@@ -1,0 +1,19 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_INIT_H
+#define MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_INIT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ms_ring_buffer ms_ring_buffer_t;
+
+int ms_ring_buffer_init(ms_ring_buffer_t **buffer, size_t capacity);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_INIT_H */

--- a/core/include/MicroSerial/functions/ms_ring_buffer_read.h
+++ b/core/include/MicroSerial/functions/ms_ring_buffer_read.h
@@ -1,0 +1,19 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_READ_H
+#define MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_READ_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ms_ring_buffer ms_ring_buffer_t;
+
+size_t ms_ring_buffer_read(ms_ring_buffer_t *buffer, uint8_t *data, size_t length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_READ_H */

--- a/core/include/MicroSerial/functions/ms_ring_buffer_size.h
+++ b/core/include/MicroSerial/functions/ms_ring_buffer_size.h
@@ -1,0 +1,19 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_SIZE_H
+#define MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_SIZE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ms_ring_buffer ms_ring_buffer_t;
+
+size_t ms_ring_buffer_size(const ms_ring_buffer_t *buffer);
+size_t ms_ring_buffer_capacity(const ms_ring_buffer_t *buffer);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_SIZE_H */

--- a/core/include/MicroSerial/functions/ms_ring_buffer_write.h
+++ b/core/include/MicroSerial/functions/ms_ring_buffer_write.h
@@ -1,0 +1,19 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_WRITE_H
+#define MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_WRITE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ms_ring_buffer ms_ring_buffer_t;
+
+size_t ms_ring_buffer_write(ms_ring_buffer_t *buffer, const uint8_t *data, size_t length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_RING_BUFFER_WRITE_H */

--- a/core/include/MicroSerial/functions/ms_serial_port_close.h
+++ b/core/include/MicroSerial/functions/ms_serial_port_close.h
@@ -1,0 +1,16 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_CLOSE_H
+#define MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_CLOSE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port;
+
+void ms_serial_port_close(struct ms_serial_port *port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_CLOSE_H */

--- a/core/include/MicroSerial/functions/ms_serial_port_configure.h
+++ b/core/include/MicroSerial/functions/ms_serial_port_configure.h
@@ -1,0 +1,17 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_CONFIGURE_H
+#define MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_CONFIGURE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port;
+struct ms_serial_config;
+
+int ms_serial_port_configure(struct ms_serial_port *port, const struct ms_serial_config *config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_CONFIGURE_H */

--- a/core/include/MicroSerial/functions/ms_serial_port_enumerate.h
+++ b/core/include/MicroSerial/functions/ms_serial_port_enumerate.h
@@ -1,0 +1,18 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_ENUMERATE_H
+#define MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_ENUMERATE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port_info;
+
+int ms_serial_port_enumerate(struct ms_serial_port_info **out_list, size_t *out_count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_ENUMERATE_H */

--- a/core/include/MicroSerial/functions/ms_serial_port_list_free.h
+++ b/core/include/MicroSerial/functions/ms_serial_port_list_free.h
@@ -1,0 +1,18 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_LIST_FREE_H
+#define MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_LIST_FREE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port_info;
+
+void ms_serial_port_list_free(struct ms_serial_port_info *list, size_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_LIST_FREE_H */

--- a/core/include/MicroSerial/functions/ms_serial_port_open.h
+++ b/core/include/MicroSerial/functions/ms_serial_port_open.h
@@ -1,0 +1,19 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_OPEN_H
+#define MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_OPEN_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port;
+struct ms_serial_config;
+
+int ms_serial_port_open(const char *path, struct ms_serial_port **out_port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_OPEN_H */

--- a/core/include/MicroSerial/functions/ms_serial_port_poll.h
+++ b/core/include/MicroSerial/functions/ms_serial_port_poll.h
@@ -1,0 +1,16 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_POLL_H
+#define MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_POLL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port;
+
+int ms_serial_port_poll(struct ms_serial_port *port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_POLL_H */

--- a/core/include/MicroSerial/functions/ms_serial_port_start.h
+++ b/core/include/MicroSerial/functions/ms_serial_port_start.h
@@ -1,0 +1,19 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_START_H
+#define MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_START_H
+
+#include "MicroSerial/os/event_loop.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port;
+
+int ms_serial_port_start(struct ms_serial_port *port, ms_serial_callbacks_t callbacks, void *user_data);
+int ms_serial_port_stop(struct ms_serial_port *port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_START_H */

--- a/core/include/MicroSerial/functions/ms_serial_port_write.h
+++ b/core/include/MicroSerial/functions/ms_serial_port_write.h
@@ -1,0 +1,20 @@
+#ifndef MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_WRITE_H
+#define MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_WRITE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port;
+
+ssize_t ms_serial_port_write(struct ms_serial_port *port, const uint8_t *data, size_t length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_FUNCTIONS_MS_SERIAL_PORT_WRITE_H */

--- a/core/include/MicroSerial/io/ring_buffer.h
+++ b/core/include/MicroSerial/io/ring_buffer.h
@@ -1,0 +1,10 @@
+#ifndef MICROSERIAL_IO_RING_BUFFER_H
+#define MICROSERIAL_IO_RING_BUFFER_H
+
+#include "MicroSerial/functions/ms_ring_buffer_init.h"
+#include "MicroSerial/functions/ms_ring_buffer_free.h"
+#include "MicroSerial/functions/ms_ring_buffer_write.h"
+#include "MicroSerial/functions/ms_ring_buffer_read.h"
+#include "MicroSerial/functions/ms_ring_buffer_size.h"
+
+#endif /* MICROSERIAL_IO_RING_BUFFER_H */

--- a/core/include/MicroSerial/io/serial.h
+++ b/core/include/MicroSerial/io/serial.h
@@ -1,0 +1,16 @@
+#ifndef MICROSERIAL_IO_SERIAL_H
+#define MICROSERIAL_IO_SERIAL_H
+
+/**
+ * @file serial.h
+ * @brief Serial session API aggregating per-function headers.
+ */
+
+#include "MicroSerial/functions/ms_serial_port_open.h"
+#include "MicroSerial/functions/ms_serial_port_configure.h"
+#include "MicroSerial/functions/ms_serial_port_start.h"
+#include "MicroSerial/functions/ms_serial_port_write.h"
+#include "MicroSerial/functions/ms_serial_port_close.h"
+#include "MicroSerial/functions/ms_serial_port_poll.h"
+
+#endif /* MICROSERIAL_IO_SERIAL_H */

--- a/core/include/MicroSerial/io/serial_config.h
+++ b/core/include/MicroSerial/io/serial_config.h
@@ -1,0 +1,48 @@
+#ifndef MICROSERIAL_IO_SERIAL_CONFIG_H
+#define MICROSERIAL_IO_SERIAL_CONFIG_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Supported parity modes.
+ */
+typedef enum ms_serial_parity {
+    MS_SERIAL_PARITY_NONE = 0,
+    MS_SERIAL_PARITY_EVEN,
+    MS_SERIAL_PARITY_ODD
+} ms_serial_parity_t;
+
+/**
+ * @brief Flow control configuration.
+ */
+typedef enum ms_serial_flow_control {
+    MS_SERIAL_FLOW_NONE = 0,
+    MS_SERIAL_FLOW_RTS_CTS,
+    MS_SERIAL_FLOW_XON_XOFF
+} ms_serial_flow_control_t;
+
+/**
+ * @brief Serial port configuration descriptor.
+ */
+typedef struct ms_serial_config {
+    uint32_t baud_rate;
+    uint8_t data_bits;
+    uint8_t stop_bits;
+    ms_serial_parity_t parity;
+    ms_serial_flow_control_t flow_control;
+    uint32_t rx_buffer_size;
+    uint32_t tx_buffer_size;
+    uint32_t read_timeout_ms;
+    uint32_t write_timeout_ms;
+} ms_serial_config_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_IO_SERIAL_CONFIG_H */

--- a/core/include/MicroSerial/io/serial_discovery.h
+++ b/core/include/MicroSerial/io/serial_discovery.h
@@ -1,0 +1,22 @@
+#ifndef MICROSERIAL_IO_SERIAL_DISCOVERY_H
+#define MICROSERIAL_IO_SERIAL_DISCOVERY_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ms_serial_port_info {
+    char path[256];
+    char description[256];
+} ms_serial_port_info_t;
+
+#include "MicroSerial/functions/ms_serial_port_enumerate.h"
+#include "MicroSerial/functions/ms_serial_port_list_free.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_IO_SERIAL_DISCOVERY_H */

--- a/core/include/MicroSerial/ms_core.h
+++ b/core/include/MicroSerial/ms_core.h
@@ -1,0 +1,28 @@
+#ifndef MICROSERIAL_MS_CORE_H
+#define MICROSERIAL_MS_CORE_H
+
+/**
+ * @file ms_core.h
+ * @brief Primary include header for MicroSerial core API.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "MicroSerial/io/serial.h"
+#include "MicroSerial/io/serial_config.h"
+#include "MicroSerial/io/serial_discovery.h"
+#include "MicroSerial/util/logging.h"
+#include "MicroSerial/util/time.h"
+#include "MicroSerial/plugins/plugin_abi.h"
+
+#define MICROSERIAL_CORE_API_VERSION_MAJOR 0
+#define MICROSERIAL_CORE_API_VERSION_MINOR 1
+#define MICROSERIAL_CORE_API_VERSION_PATCH 0
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_MS_CORE_H */

--- a/core/include/MicroSerial/os/event_loop.h
+++ b/core/include/MicroSerial/os/event_loop.h
@@ -1,0 +1,29 @@
+#ifndef MICROSERIAL_OS_EVENT_LOOP_H
+#define MICROSERIAL_OS_EVENT_LOOP_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ms_serial_port;
+
+typedef void (*ms_serial_data_callback)(const uint8_t *data, size_t length, void *user_data);
+typedef void (*ms_serial_event_callback)(int event_code, const char *message, void *user_data);
+
+typedef struct ms_serial_callbacks {
+    ms_serial_data_callback on_data;
+    ms_serial_event_callback on_event;
+} ms_serial_callbacks_t;
+
+int ms_serial_port_start(struct ms_serial_port *port, ms_serial_callbacks_t callbacks, void *user_data);
+int ms_serial_port_stop(struct ms_serial_port *port);
+int ms_serial_port_poll(struct ms_serial_port *port);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_OS_EVENT_LOOP_H */

--- a/core/include/MicroSerial/plugins/plugin_abi.h
+++ b/core/include/MicroSerial/plugins/plugin_abi.h
@@ -1,0 +1,33 @@
+#ifndef MICROSERIAL_PLUGINS_PLUGIN_ABI_H
+#define MICROSERIAL_PLUGINS_PLUGIN_ABI_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ms_plugin_context {
+    uint32_t abi_version;
+    void (*log)(ms_log_level_t level, const char *message);
+} ms_plugin_context_t;
+
+typedef struct ms_plugin_descriptor {
+    const char *identifier;
+    const char *name;
+    const char *version;
+    int (*initialize)(const ms_plugin_context_t *context);
+    void (*shutdown)(void);
+    size_t (*decode)(const uint8_t *input, size_t input_len, uint8_t *output, size_t output_len);
+} ms_plugin_descriptor_t;
+
+#define MS_PLUGIN_ABI_VERSION 1
+
+typedef const ms_plugin_descriptor_t *(*ms_plugin_query_fn)(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_PLUGINS_PLUGIN_ABI_H */

--- a/core/include/MicroSerial/util/logging.h
+++ b/core/include/MicroSerial/util/logging.h
@@ -1,0 +1,7 @@
+#ifndef MICROSERIAL_UTIL_LOGGING_H
+#define MICROSERIAL_UTIL_LOGGING_H
+
+#include "MicroSerial/functions/ms_log_set_level.h"
+#include "MicroSerial/functions/ms_log_message.h"
+
+#endif /* MICROSERIAL_UTIL_LOGGING_H */

--- a/core/include/MicroSerial/util/time.h
+++ b/core/include/MicroSerial/util/time.h
@@ -1,0 +1,16 @@
+#ifndef MICROSERIAL_UTIL_TIME_H
+#define MICROSERIAL_UTIL_TIME_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint64_t ms_time_monotonic_ns(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MICROSERIAL_UTIL_TIME_H */

--- a/core/src/io/serial_event_loop.c
+++ b/core/src/io/serial_event_loop.c
@@ -1,0 +1,265 @@
+#include "MicroSerial/os/event_loop.h"
+
+#include "MicroSerial/io/ring_buffer.h"
+#include "MicroSerial/util/logging.h"
+
+#include "serial_internal.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#include <sys/epoll.h>
+#elif defined(__APPLE__)
+#include <sys/event.h>
+#endif
+
+#define MS_SERIAL_MAX_EVENTS 4
+#define MS_SERIAL_IO_CHUNK 4096
+
+static void ms_serial_emit_event(ms_serial_port_t *port, int code, const char *message) {
+    if (port->callbacks.on_event) {
+        port->callbacks.on_event(code, message, port->user_data);
+    }
+}
+
+static void dispatch_rx(ms_serial_port_t *port) {
+    uint8_t buffer[MS_SERIAL_IO_CHUNK];
+    for (;;) {
+        ssize_t n = read(port->fd, buffer, sizeof(buffer));
+        if (n > 0) {
+            ms_ring_buffer_write(port->rx_buffer, buffer, (size_t)n);
+            if (port->callbacks.on_data) {
+                port->callbacks.on_data(buffer, (size_t)n, port->user_data);
+            }
+        } else if (n == 0) {
+            ms_serial_emit_event(port, 1, "remote closed");
+            break;
+        } else {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                break;
+            }
+            ms_serial_emit_event(port, -errno, "read error");
+            break;
+        }
+    }
+}
+
+static void dispatch_tx(ms_serial_port_t *port) {
+    if (!port->tx_buffer) {
+        return;
+    }
+    uint8_t buffer[MS_SERIAL_IO_CHUNK];
+    for (;;) {
+        size_t available = ms_ring_buffer_read(port->tx_buffer, buffer, sizeof(buffer));
+        if (available == 0) {
+            break;
+        }
+        size_t offset = 0;
+        while (offset < available) {
+            ssize_t written = write(port->fd, buffer + offset, available - offset);
+            if (written > 0) {
+                offset += (size_t)written;
+            } else if (written < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                ms_ring_buffer_write(port->tx_buffer, buffer + offset, available - offset);
+                return;
+            } else {
+                ms_serial_emit_event(port, -errno, "write error");
+                return;
+            }
+        }
+    }
+}
+
+static void *ms_serial_io_thread(void *arg) {
+    ms_serial_port_t *port = (ms_serial_port_t *)arg;
+    while (atomic_load(&port->running)) {
+        ms_serial_port_poll((struct ms_serial_port *)port);
+    }
+    return NULL;
+}
+
+#if defined(__linux__)
+static int configure_epoll(ms_serial_port_t *port) {
+    int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+    if (epoll_fd < 0) {
+        return -errno;
+    }
+    struct epoll_event ev = {0};
+    ev.events = EPOLLIN | EPOLLOUT | EPOLLERR | EPOLLHUP;
+    ev.data.fd = port->fd;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, port->fd, &ev) < 0) {
+        int err = -errno;
+        close(epoll_fd);
+        return err;
+    }
+    struct epoll_event wake_ev = {0};
+    wake_ev.events = EPOLLIN;
+    wake_ev.data.fd = port->wake_pipe[0];
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, port->wake_pipe[0], &wake_ev) < 0) {
+        int err = -errno;
+        close(epoll_fd);
+        return err;
+    }
+    port->poll_handle = epoll_fd;
+    return 0;
+}
+#elif defined(__APPLE__)
+static int configure_kqueue(ms_serial_port_t *port) {
+    int kq = kqueue();
+    if (kq < 0) {
+        return -errno;
+    }
+    struct kevent changes[2];
+    EV_SET(&changes[0], port->fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    EV_SET(&changes[1], port->fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    if (kevent(kq, changes, 2, NULL, 0, NULL) < 0) {
+        int err = -errno;
+        close(kq);
+        return err;
+    }
+    struct kevent wake_change;
+    EV_SET(&wake_change, port->wake_pipe[0], EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+    if (kevent(kq, &wake_change, 1, NULL, 0, NULL) < 0) {
+        int err = -errno;
+        close(kq);
+        return err;
+    }
+    port->poll_handle = kq;
+    return 0;
+}
+#endif
+
+int ms_serial_port_start(struct ms_serial_port *handle, ms_serial_callbacks_t callbacks, void *user_data) {
+    if (!handle) {
+        return -EINVAL;
+    }
+    ms_serial_port_t *port = (ms_serial_port_t *)handle;
+    if (!port->rx_buffer || !port->tx_buffer) {
+        return -EINVAL;
+    }
+    if (atomic_exchange(&port->running, 1) == 1) {
+        return 0;
+    }
+    port->callbacks = callbacks;
+    port->user_data = user_data;
+#if defined(__linux__)
+    int rc = configure_epoll(port);
+#elif defined(__APPLE__)
+    int rc = configure_kqueue(port);
+#else
+    int rc = -ENOTSUP;
+#endif
+    if (rc != 0) {
+        atomic_store(&port->running, 0);
+        return rc;
+    }
+    int thread_rc = pthread_create(&port->io_thread, NULL, ms_serial_io_thread, port);
+    if (thread_rc != 0) {
+        atomic_store(&port->running, 0);
+        close(port->poll_handle);
+        port->poll_handle = -1;
+        return -thread_rc;
+    }
+    return 0;
+}
+
+int ms_serial_port_stop(struct ms_serial_port *handle) {
+    if (!handle) {
+        return -EINVAL;
+    }
+    ms_serial_port_t *port = (ms_serial_port_t *)handle;
+    if (atomic_exchange(&port->running, 0) == 0) {
+        return 0;
+    }
+    if (write(port->wake_pipe[1], "s", 1) < 0) {
+        // ignore
+    }
+    pthread_join(port->io_thread, NULL);
+    if (port->poll_handle >= 0) {
+        close(port->poll_handle);
+        port->poll_handle = -1;
+    }
+    return 0;
+}
+
+int ms_serial_port_poll(struct ms_serial_port *handle) {
+    if (!handle) {
+        return -EINVAL;
+    }
+    ms_serial_port_t *port = (ms_serial_port_t *)handle;
+#if defined(__linux__)
+    struct epoll_event events[MS_SERIAL_MAX_EVENTS];
+    int timeout = (int)port->config.read_timeout_ms;
+    int n = epoll_wait(port->poll_handle, events, MS_SERIAL_MAX_EVENTS, timeout > 0 ? timeout : -1);
+    if (n < 0) {
+        if (errno == EINTR) {
+            return 0;
+        }
+        ms_serial_emit_event(port, -errno, "epoll_wait failed");
+        return -errno;
+    }
+    for (int i = 0; i < n; ++i) {
+        int fd = events[i].data.fd;
+        if (fd == port->wake_pipe[0]) {
+            uint8_t buf[16];
+            while (read(fd, buf, sizeof(buf)) > 0) {
+            }
+            continue;
+        }
+        if (events[i].events & (EPOLLERR | EPOLLHUP)) {
+            ms_serial_emit_event(port, -1, "device error");
+        }
+        if (events[i].events & EPOLLIN) {
+            dispatch_rx(port);
+        }
+        if (events[i].events & EPOLLOUT) {
+            dispatch_tx(port);
+        }
+    }
+    return 0;
+#elif defined(__APPLE__)
+    struct kevent events[MS_SERIAL_MAX_EVENTS];
+    struct timespec timeout = {0};
+    struct timespec *timeout_ptr = NULL;
+    if (port->config.read_timeout_ms > 0) {
+        timeout.tv_sec = port->config.read_timeout_ms / 1000;
+        timeout.tv_nsec = (port->config.read_timeout_ms % 1000) * 1000000L;
+        timeout_ptr = &timeout;
+    }
+    int n = kevent(port->poll_handle, NULL, 0, events, MS_SERIAL_MAX_EVENTS, timeout_ptr);
+    if (n < 0) {
+        if (errno == EINTR) {
+            return 0;
+        }
+        ms_serial_emit_event(port, -errno, "kevent failed");
+        return -errno;
+    }
+    for (int i = 0; i < n; ++i) {
+        if (events[i].ident == (uintptr_t)port->wake_pipe[0]) {
+            uint8_t buf[16];
+            while (read(port->wake_pipe[0], buf, sizeof(buf)) > 0) {
+            }
+            continue;
+        }
+        if (events[i].filter == EVFILT_READ) {
+            dispatch_rx(port);
+        }
+        if (events[i].filter == EVFILT_WRITE) {
+            dispatch_tx(port);
+        }
+        if (events[i].flags & EV_ERROR) {
+            ms_serial_emit_event(port, events[i].data, "device error");
+        }
+    }
+    return 0;
+#else
+    (void)port;
+    return -ENOTSUP;
+#endif
+}

--- a/core/src/io/serial_internal.h
+++ b/core/src/io/serial_internal.h
@@ -1,0 +1,30 @@
+#ifndef MICROSERIAL_SERIAL_INTERNAL_H
+#define MICROSERIAL_SERIAL_INTERNAL_H
+
+#include "MicroSerial/io/serial_config.h"
+#include "MicroSerial/os/event_loop.h"
+#include "MicroSerial/io/ring_buffer.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
+
+typedef struct ms_ring_buffer ms_ring_buffer_t;
+
+typedef struct ms_serial_port {
+    int fd;
+    ms_serial_config_t config;
+    ms_ring_buffer_t *rx_buffer;
+    ms_ring_buffer_t *tx_buffer;
+    ms_serial_callbacks_t callbacks;
+    void *user_data;
+    pthread_t io_thread;
+    _Atomic int running;
+    int wake_pipe[2];
+    int poll_handle;
+    pthread_mutex_t tx_mutex;
+} ms_serial_port_t;
+
+int ms_posix_configure_port(int fd, const ms_serial_config_t *config);
+int ms_posix_apply_flow_control(int fd, ms_serial_flow_control_t flow);
+
+#endif /* MICROSERIAL_SERIAL_INTERNAL_H */

--- a/core/src/io/serial_port.c
+++ b/core/src/io/serial_port.c
@@ -1,0 +1,126 @@
+#include "MicroSerial/io/serial.h"
+
+#include "MicroSerial/io/ring_buffer.h"
+
+#include "serial_internal.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int ms_serial_port_open(const char *path, struct ms_serial_port **out_port) {
+    if (!path || !out_port) {
+        return -EINVAL;
+    }
+
+    int fd = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd < 0) {
+        return -errno;
+    }
+
+    ms_serial_port_t *port = calloc(1, sizeof(*port));
+    if (!port) {
+        close(fd);
+        return -ENOMEM;
+    }
+
+    port->fd = fd;
+    port->rx_buffer = NULL;
+    port->tx_buffer = NULL;
+    port->callbacks.on_data = NULL;
+    port->callbacks.on_event = NULL;
+    port->user_data = NULL;
+    atomic_store(&port->running, 0);
+    port->poll_handle = -1;
+    if (pipe(port->wake_pipe) < 0) {
+        close(fd);
+        free(port);
+        return -errno;
+    }
+    fcntl(port->wake_pipe[0], F_SETFL, O_NONBLOCK);
+    fcntl(port->wake_pipe[1], F_SETFL, O_NONBLOCK);
+    pthread_mutex_init(&port->tx_mutex, NULL);
+
+    *out_port = (struct ms_serial_port *)port;
+    return 0;
+}
+
+int ms_serial_port_configure(struct ms_serial_port *handle, const struct ms_serial_config *config) {
+    if (!handle || !config) {
+        return -EINVAL;
+    }
+    ms_serial_port_t *port = (ms_serial_port_t *)handle;
+    int rc = ms_posix_configure_port(port->fd, config);
+    if (rc != 0) {
+        return rc;
+    }
+    if (port->rx_buffer) {
+        ms_ring_buffer_free(port->rx_buffer);
+        port->rx_buffer = NULL;
+    }
+    if (port->tx_buffer) {
+        ms_ring_buffer_free(port->tx_buffer);
+        port->tx_buffer = NULL;
+    }
+    if (ms_ring_buffer_init(&port->rx_buffer, config->rx_buffer_size) != 0) {
+        return -ENOMEM;
+    }
+    if (ms_ring_buffer_init(&port->tx_buffer, config->tx_buffer_size) != 0) {
+        ms_ring_buffer_free(port->rx_buffer);
+        port->rx_buffer = NULL;
+        return -ENOMEM;
+    }
+    port->config = *config;
+    return 0;
+}
+
+ssize_t ms_serial_port_write(struct ms_serial_port *handle, const uint8_t *data, size_t length) {
+    if (!handle || !data || length == 0) {
+        return -EINVAL;
+    }
+    ms_serial_port_t *port = (ms_serial_port_t *)handle;
+    if (!port->tx_buffer) {
+        return -EPIPE;
+    }
+    pthread_mutex_lock(&port->tx_mutex);
+    size_t written = ms_ring_buffer_write(port->tx_buffer, data, length);
+    pthread_mutex_unlock(&port->tx_mutex);
+    if (written == 0) {
+        return 0;
+    }
+    if (write(port->wake_pipe[1], "w", 1) < 0) {
+        // Ignored; pipe is non-blocking
+    }
+    return (ssize_t)written;
+}
+
+void ms_serial_port_close(struct ms_serial_port *handle) {
+    if (!handle) {
+        return;
+    }
+    ms_serial_port_t *port = (ms_serial_port_t *)handle;
+    ms_serial_port_stop(handle);
+    if (port->fd >= 0) {
+        close(port->fd);
+        port->fd = -1;
+    }
+    if (port->wake_pipe[0] >= 0) {
+        close(port->wake_pipe[0]);
+        port->wake_pipe[0] = -1;
+    }
+    if (port->wake_pipe[1] >= 0) {
+        close(port->wake_pipe[1]);
+        port->wake_pipe[1] = -1;
+    }
+    if (port->rx_buffer) {
+        ms_ring_buffer_free(port->rx_buffer);
+    }
+    if (port->tx_buffer) {
+        ms_ring_buffer_free(port->tx_buffer);
+    }
+    pthread_mutex_destroy(&port->tx_mutex);
+    free(port);
+}

--- a/core/src/os/port_enumeration.c
+++ b/core/src/os/port_enumeration.c
@@ -1,0 +1,95 @@
+#include "MicroSerial/io/serial_discovery.h"
+
+#include <errno.h>
+#include <glob.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+static bool path_exists(const char *path) {
+    struct stat st;
+    return stat(path, &st) == 0;
+}
+
+static bool contains_path(ms_serial_port_info_t *list, size_t count, const char *path) {
+    for (size_t i = 0; i < count; ++i) {
+        if (strncmp(list[i].path, path, sizeof(list[i].path)) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static int append_port(ms_serial_port_info_t **list, size_t *count, size_t *capacity, const char *path) {
+    if (!path_exists(path)) {
+        return 0;
+    }
+    if (contains_path(*list, *count, path)) {
+        return 0;
+    }
+    if (*count >= *capacity) {
+        size_t new_capacity = *capacity == 0 ? 8 : (*capacity * 2);
+        ms_serial_port_info_t *resized = realloc(*list, new_capacity * sizeof(ms_serial_port_info_t));
+        if (!resized) {
+            return -ENOMEM;
+        }
+        *list = resized;
+        *capacity = new_capacity;
+    }
+    ms_serial_port_info_t *info = &(*list)[*count];
+    memset(info, 0, sizeof(*info));
+    snprintf(info->path, sizeof(info->path), "%s", path);
+    snprintf(info->description, sizeof(info->description), "Serial device %s", path);
+    (*count)++;
+    return 0;
+}
+
+int ms_serial_port_enumerate(ms_serial_port_info_t **out_list, size_t *out_count) {
+    if (!out_list || !out_count) {
+        return -EINVAL;
+    }
+    *out_list = NULL;
+    *out_count = 0;
+
+#if defined(__APPLE__)
+    const char *patterns[] = {"/dev/tty.*", "/dev/cu.*"};
+#else
+    const char *patterns[] = {"/dev/ttyS*", "/dev/ttyUSB*", "/dev/ttyACM*", "/dev/ttyAMA*", "/dev/ttyPS*", "/dev/tty.*"};
+#endif
+
+    ms_serial_port_info_t *list = NULL;
+    size_t count = 0;
+    size_t capacity = 0;
+
+    for (size_t i = 0; i < sizeof(patterns) / sizeof(patterns[0]); ++i) {
+        glob_t results;
+        memset(&results, 0, sizeof(results));
+        if (glob(patterns[i], GLOB_NOCHECK, NULL, &results) != 0) {
+            globfree(&results);
+            continue;
+        }
+        for (size_t j = 0; j < results.gl_pathc; ++j) {
+            const char *path = results.gl_pathv[j];
+            if (!path || strstr(path, "*") != NULL) {
+                continue;
+            }
+            if (append_port(&list, &count, &capacity, path) != 0) {
+                globfree(&results);
+                free(list);
+                return -ENOMEM;
+            }
+        }
+        globfree(&results);
+    }
+
+    *out_list = list;
+    *out_count = count;
+    return 0;
+}
+
+void ms_serial_port_list_free(ms_serial_port_info_t *list, size_t count) {
+    (void)count;
+    free(list);
+}

--- a/core/src/os/posix_serial.c
+++ b/core/src/os/posix_serial.c
@@ -1,0 +1,140 @@
+#define _DEFAULT_SOURCE
+
+#include "io/serial_internal.h"
+
+#include "MicroSerial/util/logging.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+
+static speed_t baud_to_speed(uint32_t baud) {
+    switch (baud) {
+        case 9600:
+            return B9600;
+        case 19200:
+            return B19200;
+        case 38400:
+            return B38400;
+        case 57600:
+            return B57600;
+        case 115200:
+            return B115200;
+        case 230400:
+            return B230400;
+        case 460800:
+            return B460800;
+        case 921600:
+            return B921600;
+        default:
+            return B115200;
+    }
+}
+
+static int apply_baud_rate(int fd, speed_t speed) {
+    struct termios tio;
+    if (tcgetattr(fd, &tio) < 0) {
+        return -errno;
+    }
+    cfsetispeed(&tio, speed);
+    cfsetospeed(&tio, speed);
+    if (tcsetattr(fd, TCSANOW, &tio) < 0) {
+        return -errno;
+    }
+    return 0;
+}
+
+int ms_posix_apply_flow_control(int fd, ms_serial_flow_control_t flow) {
+    struct termios tio;
+    if (tcgetattr(fd, &tio) < 0) {
+        return -errno;
+    }
+    tio.c_iflag &= ~(IXON | IXOFF | IXANY);
+#ifdef CRTSCTS
+    tio.c_cflag &= ~CRTSCTS;
+#endif
+    switch (flow) {
+        case MS_SERIAL_FLOW_RTS_CTS:
+#ifdef CRTSCTS
+            tio.c_cflag |= CRTSCTS;
+#else
+            ms_log_message(MS_LOG_LEVEL_WARN, "RTS/CTS not supported on this platform");
+#endif
+            break;
+        case MS_SERIAL_FLOW_XON_XOFF:
+            tio.c_iflag |= IXON | IXOFF;
+            break;
+        case MS_SERIAL_FLOW_NONE:
+        default:
+            break;
+    }
+    if (tcsetattr(fd, TCSANOW, &tio) < 0) {
+        return -errno;
+    }
+    return 0;
+}
+
+int ms_posix_configure_port(int fd, const ms_serial_config_t *config) {
+    if (!config) {
+        return -EINVAL;
+    }
+    struct termios tio;
+    if (tcgetattr(fd, &tio) < 0) {
+        return -errno;
+    }
+
+    cfmakeraw(&tio);
+
+    tio.c_cflag &= ~CSIZE;
+    switch (config->data_bits) {
+        case 5:
+            tio.c_cflag |= CS5;
+            break;
+        case 6:
+            tio.c_cflag |= CS6;
+            break;
+        case 7:
+            tio.c_cflag |= CS7;
+            break;
+        case 8:
+        default:
+            tio.c_cflag |= CS8;
+            break;
+    }
+
+    if (config->stop_bits == 2) {
+        tio.c_cflag |= CSTOPB;
+    } else {
+        tio.c_cflag &= ~CSTOPB;
+    }
+
+    tio.c_cflag &= ~(PARENB | PARODD);
+    if (config->parity == MS_SERIAL_PARITY_EVEN) {
+        tio.c_cflag |= PARENB;
+        tio.c_cflag &= ~PARODD;
+    } else if (config->parity == MS_SERIAL_PARITY_ODD) {
+        tio.c_cflag |= PARENB;
+        tio.c_cflag |= PARODD;
+    }
+
+    tio.c_cc[VMIN] = 0;
+    tio.c_cc[VTIME] = (config->read_timeout_ms + 99) / 100;
+
+    if (tcsetattr(fd, TCSANOW, &tio) < 0) {
+        return -errno;
+    }
+
+    int rc = apply_baud_rate(fd, baud_to_speed(config->baud_rate));
+    if (rc != 0) {
+        return rc;
+    }
+    rc = ms_posix_apply_flow_control(fd, config->flow_control);
+    if (rc != 0) {
+        return rc;
+    }
+
+    tcflush(fd, TCIOFLUSH);
+    return 0;
+}

--- a/core/src/util/logging.c
+++ b/core/src/util/logging.c
@@ -1,0 +1,41 @@
+#include "MicroSerial/util/logging.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdatomic.h>
+
+static _Atomic ms_log_level_t g_log_level = MS_LOG_LEVEL_INFO;
+
+void ms_log_set_level(ms_log_level_t level) {
+    atomic_store(&g_log_level, level);
+}
+
+void ms_log_message(ms_log_level_t level, const char *fmt, ...) {
+    if (level > atomic_load(&g_log_level)) {
+        return;
+    }
+    const char *prefix = "INFO";
+    switch (level) {
+        case MS_LOG_LEVEL_ERROR:
+            prefix = "ERROR";
+            break;
+        case MS_LOG_LEVEL_WARN:
+            prefix = "WARN";
+            break;
+        case MS_LOG_LEVEL_INFO:
+            prefix = "INFO";
+            break;
+        case MS_LOG_LEVEL_DEBUG:
+            prefix = "DEBUG";
+            break;
+        case MS_LOG_LEVEL_TRACE:
+            prefix = "TRACE";
+            break;
+    }
+    va_list args;
+    va_start(args, fmt);
+    fprintf(stderr, "[MicroSerial][%s] ", prefix);
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+}

--- a/core/src/util/ring_buffer.c
+++ b/core/src/util/ring_buffer.c
@@ -1,0 +1,111 @@
+#include "MicroSerial/io/ring_buffer.h"
+
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct ms_ring_buffer {
+    uint8_t *data;
+    size_t capacity;
+    _Atomic size_t head;
+    _Atomic size_t tail;
+};
+
+typedef struct ms_ring_buffer ms_ring_buffer_t;
+
+static size_t next_power_of_two(size_t value) {
+    if (value < 2) {
+        return 2;
+    }
+    value--;
+    value |= value >> 1;
+    value |= value >> 2;
+    value |= value >> 4;
+    value |= value >> 8;
+    value |= value >> 16;
+#if SIZE_MAX > UINT32_MAX
+    value |= value >> 32;
+#endif
+    value++;
+    return value;
+}
+
+int ms_ring_buffer_init(ms_ring_buffer_t **buffer, size_t capacity) {
+    if (!buffer || capacity == 0) {
+        return -1;
+    }
+    ms_ring_buffer_t *rb = calloc(1, sizeof(*rb));
+    if (!rb) {
+        return -2;
+    }
+    rb->capacity = next_power_of_two(capacity);
+    rb->data = calloc(rb->capacity, sizeof(uint8_t));
+    if (!rb->data) {
+        free(rb);
+        return -3;
+    }
+    atomic_store(&rb->head, 0);
+    atomic_store(&rb->tail, 0);
+    *buffer = rb;
+    return 0;
+}
+
+void ms_ring_buffer_free(ms_ring_buffer_t *buffer) {
+    if (!buffer) {
+        return;
+    }
+    free(buffer->data);
+    free(buffer);
+}
+
+static size_t ring_distance(size_t head, size_t tail, size_t capacity) {
+    return (head - tail) & (capacity - 1);
+}
+
+size_t ms_ring_buffer_size(const ms_ring_buffer_t *buffer) {
+    if (!buffer) {
+        return 0;
+    }
+    size_t head = atomic_load(&buffer->head);
+    size_t tail = atomic_load(&buffer->tail);
+    return ring_distance(head, tail, buffer->capacity);
+}
+
+size_t ms_ring_buffer_capacity(const ms_ring_buffer_t *buffer) {
+    if (!buffer) {
+        return 0;
+    }
+    return buffer->capacity;
+}
+
+size_t ms_ring_buffer_write(ms_ring_buffer_t *buffer, const uint8_t *data, size_t length) {
+    if (!buffer || !data || length == 0) {
+        return 0;
+    }
+    size_t head = atomic_load_explicit(&buffer->head, memory_order_relaxed);
+    size_t tail = atomic_load_explicit(&buffer->tail, memory_order_acquire);
+    size_t available = buffer->capacity - ring_distance(head, tail, buffer->capacity) - 1;
+    size_t to_write = length < available ? length : available;
+    for (size_t i = 0; i < to_write; ++i) {
+        buffer->data[head] = data[i];
+        head = (head + 1) & (buffer->capacity - 1);
+    }
+    atomic_store_explicit(&buffer->head, head, memory_order_release);
+    return to_write;
+}
+
+size_t ms_ring_buffer_read(ms_ring_buffer_t *buffer, uint8_t *data, size_t length) {
+    if (!buffer || !data || length == 0) {
+        return 0;
+    }
+    size_t head = atomic_load_explicit(&buffer->head, memory_order_acquire);
+    size_t tail = atomic_load_explicit(&buffer->tail, memory_order_relaxed);
+    size_t available = ring_distance(head, tail, buffer->capacity);
+    size_t to_read = length < available ? length : available;
+    for (size_t i = 0; i < to_read; ++i) {
+        data[i] = buffer->data[tail];
+        tail = (tail + 1) & (buffer->capacity - 1);
+    }
+    atomic_store_explicit(&buffer->tail, tail, memory_order_release);
+    return to_read;
+}

--- a/core/src/util/time.c
+++ b/core/src/util/time.c
@@ -1,0 +1,15 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "MicroSerial/util/time.h"
+
+#include <time.h>
+
+uint64_t ms_time_monotonic_ns(void) {
+    struct timespec ts = {0};
+#if defined(CLOCK_MONOTONIC_RAW)
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+#else
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(serial_loopback_test serial_loopback_test.c)
+target_link_libraries(serial_loopback_test PRIVATE microserial_core)
+add_test(NAME serial_loopback_test COMMAND serial_loopback_test)

--- a/core/tests/serial_loopback_test.c
+++ b/core/tests/serial_loopback_test.c
@@ -1,0 +1,146 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "MicroSerial/ms_core.h"
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <pty.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    size_t received;
+    uint8_t buffer[1024];
+} callback_ctx_t;
+
+static void on_data(const uint8_t *data, size_t length, void *user_data) {
+    callback_ctx_t *ctx = (callback_ctx_t *)user_data;
+    pthread_mutex_lock(&ctx->mutex);
+    size_t copy = length < sizeof(ctx->buffer) ? length : sizeof(ctx->buffer);
+    memcpy(ctx->buffer, data, copy);
+    ctx->received = copy;
+    pthread_cond_signal(&ctx->cond);
+    pthread_mutex_unlock(&ctx->mutex);
+}
+
+static void on_event(int code, const char *message, void *user_data) {
+    (void)code;
+    (void)message;
+    (void)user_data;
+}
+
+static int wait_for_data(callback_ctx_t *ctx) {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += 2;
+    pthread_mutex_lock(&ctx->mutex);
+    int rc = 0;
+    while (ctx->received == 0 && rc == 0) {
+        rc = pthread_cond_timedwait(&ctx->cond, &ctx->mutex, &ts);
+    }
+    pthread_mutex_unlock(&ctx->mutex);
+    return rc;
+}
+
+int main(void) {
+    int master_fd = -1;
+    int slave_fd = -1;
+    char slave_name[128];
+    if (openpty(&master_fd, &slave_fd, slave_name, NULL, NULL) < 0) {
+        perror("openpty");
+        return EXIT_FAILURE;
+    }
+    close(slave_fd);
+
+    struct ms_serial_port *port = NULL;
+    if (ms_serial_port_open(slave_name, &port) != 0) {
+        fprintf(stderr, "failed to open serial port\n");
+        return EXIT_FAILURE;
+    }
+
+    ms_serial_config_t config = {
+        .baud_rate = 115200,
+        .data_bits = 8,
+        .stop_bits = 1,
+        .parity = MS_SERIAL_PARITY_NONE,
+        .flow_control = MS_SERIAL_FLOW_NONE,
+        .rx_buffer_size = 8192,
+        .tx_buffer_size = 8192,
+        .read_timeout_ms = 100,
+        .write_timeout_ms = 100,
+    };
+
+    if (ms_serial_port_configure(port, &config) != 0) {
+        fprintf(stderr, "failed to configure\n");
+        return EXIT_FAILURE;
+    }
+
+    callback_ctx_t ctx;
+    pthread_mutex_init(&ctx.mutex, NULL);
+    pthread_cond_init(&ctx.cond, NULL);
+    ctx.received = 0;
+
+    ms_serial_callbacks_t callbacks = {
+        .on_data = on_data,
+        .on_event = on_event,
+    };
+
+    if (ms_serial_port_start(port, callbacks, &ctx) != 0) {
+        fprintf(stderr, "failed to start io\n");
+        return EXIT_FAILURE;
+    }
+
+    const char inbound[] = "hello core";
+    if (write(master_fd, inbound, sizeof(inbound)) < 0) {
+        perror("write inbound");
+        return EXIT_FAILURE;
+    }
+
+    if (wait_for_data(&ctx) != 0) {
+        fprintf(stderr, "timeout waiting for inbound\n");
+        return EXIT_FAILURE;
+    }
+
+    if (ctx.received != sizeof(inbound)) {
+        fprintf(stderr, "unexpected inbound length\n");
+        return EXIT_FAILURE;
+    }
+
+    const char outbound[] = "hello device";
+    ssize_t wrote = ms_serial_port_write(port, (const uint8_t *)outbound, sizeof(outbound));
+    if (wrote <= 0) {
+        fprintf(stderr, "failed to write outbound\n");
+        return EXIT_FAILURE;
+    }
+
+    char verify[64] = {0};
+    ssize_t read_bytes = read(master_fd, verify, sizeof(verify));
+    if (read_bytes <= 0) {
+        fprintf(stderr, "failed to read outbound data\n");
+        return EXIT_FAILURE;
+    }
+
+    if (memcmp(verify, outbound, sizeof(outbound)) != 0) {
+        fprintf(stderr, "outbound mismatch\n");
+        return EXIT_FAILURE;
+    }
+
+    ms_serial_port_stop(port);
+    ms_serial_port_close(port);
+
+    close(master_fd);
+    pthread_mutex_destroy(&ctx.mutex);
+    pthread_cond_destroy(&ctx.cond);
+
+    return EXIT_SUCCESS;
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,50 @@
+# Build & Run Guide
+
+## Prerequisites
+
+* **Linux or macOS** with POSIX toolchain
+* CMake ≥ 3.18, Clang/GCC with C11 support
+* Rust toolchain (stable) + Cargo
+* `pkg-config`, `clang`, and development headers for X11/Wayland (auto-pulled by egui/wgpu)
+
+## Build the C Core
+
+```
+cmake -S core -B build/core -DCMAKE_BUILD_TYPE=Release
+cmake --build build/core --config Release
+ctest --test-dir build/core
+```
+
+## Build the GUI (Rust)
+
+The Rust crate drives CMake automatically through `build.rs`, compiling the static core and regenerating FFI bindings.
+
+```
+cargo build --manifest-path gui/Cargo.toml
+```
+
+The binary lives under `target/debug/microserial_gui` (or `target/release/...`).
+
+## Combined Build Script
+
+```
+./scripts/build_all.sh
+```
+
+## Running the Loopback Demo
+
+The integration test uses a pseudo-terminal pair to emulate a serial cable. Run it via CTest or directly:
+
+```
+ctest --test-dir build/core -R serial_loopback_test
+```
+
+For an interactive UI smoke-test without hardware, start the GUI and select one of the pseudo-terminals exposed under `/dev/pts/*`. Use `socat -d -d pty,raw,echo=0 pty,raw,echo=0` to create loopback pairs for experimentation.
+
+## Tooling
+
+* `clang-format` / `clang-tidy` – run against `core/`
+* `rustfmt` / `cargo clippy` – run within `gui/`
+* `scripts/build_all.sh` – builds both layers reproducibly
+
+CI recipes (GitHub Actions) should execute the same steps on Linux and macOS runners.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,111 @@
+# MicroSerial Architecture Design
+
+## 1. Overview
+
+MicroSerial is a cross-platform serial communications toolchain split into a hardened C core and a modern Rust graphical client. The core delivers deterministic, low-latency serial I/O with a plugin-friendly architecture, while the GUI focuses on user experience, orchestration, and future extensibility. The project embraces a layered approach to keep responsibilities isolated and APIs stable.
+
+```
++-------------------------------------------------------------+
+|                         GUI (Rust)                          |
+|  egui/eframe UI  |  Profile mgmt  |  Recorder  |  FFI layer |
++------------------+----------------+------------+------------+
+          |                |               |          ^
+          v                v               v          |
++-------------------------------------------------------------+
+|                   Rust FFI Safe Wrapper Layer               |
+|  Safe bindings to ms_core.h  |  Session orchestration        |
++------------------------------+------------------------------+
+                              |
+                              v
++-------------------------------------------------------------+
+|                         Core (C11)                          |
+|  util   |   io (serial, buffers)   | os (epoll/kqueue) | proto |
+| logging |   ring buffers           | discovery          | ABI   |
++---------+--------------------------+--------------------+-------+
+                              |
+                              v
++-------------------------------------------------------------+
+|                    Operating System Services                |
+|  POSIX termios  |  epoll/kqueue  |  pthreads  |  Filesystem |
++-------------------------------------------------------------+
+```
+
+Key design tenets:
+
+* **Isolation:** GUI never touches file descriptors directly; it can only interact through the stable `ms_core.h` API.
+* **Throughput-first:** All data paths are zero-copy once inside the core; the GUI receives already-buffered slices.
+* **Safety:** Strict validation, defensive defaults, and extensive error propagation guard against malformed input and privilege escalation.
+
+## 2. Module Responsibilities
+
+### Core (`core/`)
+
+* **`io/`** – Serial session lifecycle, DMA-friendly ring buffers, async event loop, and flow-control aware write scheduling.
+* **`os/`** – Platform shims (termios configuration, epoll/kqueue wiring, device discovery).
+* **`util/`** – Logging, high-resolution time, lock-free SPSC ring buffer.
+* **`proto/`** – Reserved for future protocol parsers and plugin dispatch.
+* **`plugins/`** – Stable ABI for third-party protocol decoders, sandboxed via capability-aware callbacks.
+
+Each exported function lives in its own header under `include/MicroSerial/functions/`, while module headers (e.g., `io/serial.h`) aggregate related calls to keep the public surface explicit and versionable.
+
+### Rust GUI (`gui/`)
+
+* **`core.rs`** – Safe wrapper around the generated FFI bindings. Handles pointer ownership, callback trampolines, and idiomatic errors.
+* **`main.rs`** – egui/eframe powered desktop shell with port discovery, console view, transmit pane, and hot-refresh.
+* **`build.rs`** – Invokes the CMake toolchain, compiles the core static library, and uses `bindgen` to regenerate bindings automatically.
+
+### Plugins (`plugins/`)
+
+* Placeholder for first-class decoders (COBS, SLIP, binary analyzers). Each plugin exports `ms_plugin_query_fn` returning metadata, init/shutdown hooks, and a pure function for decoding/transforming frames.
+
+### Docs & Scripts
+
+* **`docs/`** – Architecture, build, testing, security, and roadmap documentation.
+* **`scripts/`** – Repeatable build/test automation entrypoints.
+
+## 3. Threading & Event Model
+
+1. **GUI thread (Rust)** – Handles user events, orchestrates sessions, drains message channels from the C callbacks, and keeps the UI responsive at 60 FPS.
+2. **I/O thread (C)** – Spawned per open port. Uses epoll (Linux) or kqueue (macOS) to multiplex serial fd readiness with the wake pipe. The thread:
+   * Reads available bytes into a stack buffer, pushes them into the RX ring, and immediately notifies registered callbacks.
+   * Flushes TX ring data using batched writes when the device is writable, honoring flow control.
+   * Emits state transitions and errors through the event callback.
+3. **Producer/Consumer discipline** – Application code writes into the TX ring under a fast mutex, while the I/O thread reads and writes to the device. The RX ring is written by the I/O thread and consumable by higher-level parsers.
+
+The wake pipe provides backpressure: writers poke the pipe to signal pending outbound data, and the event loop monitors the pipe alongside the serial fd.
+
+## 4. Data Flow (Open → Configure → Read/Write → Close)
+
+1. **Open** – `ms_serial_port_open` validates parameters, opens the fd with `O_NONBLOCK|O_NOCTTY`, prepares wake pipes, and initializes internal state.
+2. **Configure** – `ms_serial_port_configure` applies sanitized settings via termios, configures flow control, and reinitializes RX/TX ring buffers sized per profile.
+3. **Start** – `ms_serial_port_start` registers callbacks, arms epoll/kqueue, and launches the dedicated thread.
+4. **I/O** – The event loop reads/writes in `4096` byte batches, guarding against EAGAIN/flow stalls and bubbling errors via callbacks.
+5. **Write API** – `ms_serial_port_write` enqueues data atomically; partial writes return the number of bytes accepted so higher layers can backpressure.
+6. **Close** – `ms_serial_port_stop` cancels the thread, drains the wake pipe, closes handles, and destroys buffers.
+
+## 5. Plugin System
+
+The C ABI is defined in `plugins/plugin_abi.h`. Plugins are shared objects providing:
+
+* **Descriptor metadata** – Identifier, human-readable name, semantic version.
+* **Lifecycle hooks** – `initialize` receives a restricted context (logging callback and ABI version); `shutdown` allows deterministic cleanup.
+* **Decode entrypoint** – Stateless transform (`decode`) for converting raw frames into decoded payloads. Future extensions will provide structured metadata and sandbox policies (rate limits, capability flags).
+
+The core will host a plugin manager responsible for discovery (`dlopen`/`dlsym`), ABI negotiation, and sandboxing (pledges, seccomp where available). Rust GUI modules will surface plugin output as alternate console views (hex, structured, graphs).
+
+## 6. Security Posture
+
+* **Defensive defaults** – No auto-execution, telemetry opt-in only, strict bounds checks, and immediate error bubbling.
+* **Hardening flags** – `-fstack-protector-strong` and `_FORTIFY_SOURCE=2` enabled by default; ASan/UBSan optional toggles for CI.
+* **Ownership clarity** – Each allocation has a single owner; ring buffers use atomics, not raw pointer arithmetic.
+* **Input validation** – Termios parameters clamped, enumeration ignores non-existent files, and plugins run behind stable ABI boundaries.
+
+## 7. Extensibility & Next Steps
+
+* **Multi-port orchestration** – Extend the GUI to manage multiple open sessions with tabbed or tiled layouts.
+* **Protocol decoders** – Implement bundled plugins (COBS, SLIP, Modbus) plus scripting hooks (Lua/Python) through the plugin ABI.
+* **Recorder & exporter** – Stream RX data to `.bin` and `.pcapng` with JSON metadata, plus indexing for search.
+* **Profiling and benchmarks** – Integrate Criterion-based harness for latency and throughput; document results in `docs/performance.md`.
+* **Security hardening** – Sandboxed plugin host with seccomp/macOS sandbox profiles, threat model expansion, and fuzz coverage.
+
+This design keeps the system maintainable, high-performance, and ready for rapid evolution into a professional-grade serial analysis suite.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,22 @@
+# MicroSerial Roadmap
+
+## Short Term (0–3 months)
+
+* **Protocol Views** – Hex/mixed inspectors, framing analyzers (ASCII, binary, COBS, SLIP) surfaced via plugin ABI.
+* **Recorder MVP** – Lossless session capture, metadata JSON export, `.pcapng` writer for Wireshark interoperability.
+* **Profiles & Presets** – Persisted device configurations with quick-switch palette and hotkeys.
+* **CI Hardening** – Linux/macOS runners executing ASan/UBSan variants, fuzz harness via libFuzzer for parsers.
+
+## Mid Term (3–6 months)
+
+* **Multi-session UI** – Split-screen or tabbed layouts, synchronized timelines, aggregated logging.
+* **Scripting Engine** – Sandboxed Lua or WASM environment for macros, triggers, and automation.
+* **Visualization** – Inline oscilloscopes, traffic graphs, and throughput dashboards leveraging recorded metrics.
+* **Security Sandbox** – seccomp-bpf profiles on Linux, macOS App Sandbox templates, capability-limited plugin contexts.
+
+## Long Term (6–12 months)
+
+* **Headless Daemon** – Core service exposing gRPC/REST for remote monitoring and integration with CI rigs.
+* **Embedded Targets** – Cross-compilation story for ARM SBCs, packaging as snaps/AppImages/Homebrew formula.
+* **Advanced Analytics** – Protocol-specific decoders (CAN, Modbus, LIN), anomaly detection, ML-assisted heuristics.
+* **Enterprise Features** – Signed update channel, telemetry opt-in with transparent governance, role-based workspace sharing.

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "microserial_gui"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+eframe = { version = "0.26", default-features = false, features = ["wgpu"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+libc = "0.2"
+env_logger = "0.11"
+
+[build-dependencies]
+cmake = "0.1"
+bindgen = { version = "0.69", default-features = false, features = ["runtime"] }

--- a/gui/build.rs
+++ b/gui/build.rs
@@ -1,0 +1,43 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let core_dir = PathBuf::from("../core");
+    println!(
+        "cargo:rerun-if-changed={}",
+        core_dir.join("include/MicroSerial/ms_core.h").display()
+    );
+    println!("cargo:rerun-if-changed={}", core_dir.join("src").display());
+    println!(
+        "cargo:rerun-if-changed={}",
+        core_dir.join("CMakeLists.txt").display()
+    );
+
+    let dst = cmake::Config::new(&core_dir)
+        .define("BUILD_TESTING", "OFF")
+        .profile("Release")
+        .build();
+
+    let lib_dir = if dst.join("lib64").exists() {
+        dst.join("lib64")
+    } else {
+        dst.join("lib")
+    };
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:rustc-link-lib=static=microserial_core");
+    println!("cargo:rustc-link-lib=dylib=pthread");
+
+    let header_path = core_dir.join("include/MicroSerial/ms_core.h");
+    let bindings = bindgen::Builder::default()
+        .header(header_path.to_string_lossy().into_owned())
+        .allowlist_function("ms_.*")
+        .allowlist_type("ms_.*")
+        .allowlist_var("MS_.*")
+        .generate()
+        .expect("unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("could not write bindings");
+}

--- a/gui/src/core.rs
+++ b/gui/src/core.rs
@@ -1,0 +1,153 @@
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int, c_void};
+use std::ptr;
+use std::slice;
+use std::sync::{Arc, Mutex};
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+pub struct SerialPort {
+    handle: *mut ms_serial_port,
+    callbacks: Option<Arc<CallbackState>>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SerialDevice {
+    pub path: String,
+    pub description: String,
+}
+
+struct CallbackState {
+    on_data: Mutex<Box<dyn FnMut(&[u8]) + Send + 'static>>,
+    on_event: Mutex<Box<dyn FnMut(i32, &str) + Send + 'static>>,
+}
+
+unsafe extern "C" fn data_trampoline(data: *const u8, length: usize, user_data: *mut c_void) {
+    if data.is_null() || user_data.is_null() {
+        return;
+    }
+    let slice = slice::from_raw_parts(data, length);
+    let state = &*(user_data as *const CallbackState);
+    if let Ok(mut guard) = state.on_data.lock() {
+        (guard.as_mut())(slice);
+    }
+}
+
+unsafe extern "C" fn event_trampoline(code: c_int, message: *const c_char, user_data: *mut c_void) {
+    if user_data.is_null() {
+        return;
+    }
+    let state = &*(user_data as *const CallbackState);
+    let msg = if !message.is_null() {
+        CStr::from_ptr(message).to_string_lossy().to_string()
+    } else {
+        String::new()
+    };
+    if let Ok(mut guard) = state.on_event.lock() {
+        (guard.as_mut())(code, &msg);
+    }
+}
+
+impl SerialPort {
+    pub fn open(path: &str) -> Result<Self, i32> {
+        let c_path = CString::new(path).map_err(|_| libc::EINVAL)?;
+        let mut handle: *mut ms_serial_port = ptr::null_mut();
+        let rc = unsafe { ms_serial_port_open(c_path.as_ptr(), &mut handle) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(Self {
+            handle,
+            callbacks: None,
+        })
+    }
+
+    pub fn configure(&mut self, config: &ms_serial_config) -> Result<(), i32> {
+        let rc = unsafe { ms_serial_port_configure(self.handle, config) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(())
+    }
+
+    pub fn start<F, E>(&mut self, data_cb: F, event_cb: E) -> Result<(), i32>
+    where
+        F: FnMut(&[u8]) + Send + 'static,
+        E: FnMut(i32, &str) + Send + 'static,
+    {
+        let state = Arc::new(CallbackState {
+            on_data: Mutex::new(Box::new(data_cb)),
+            on_event: Mutex::new(Box::new(event_cb)),
+        });
+        let callbacks = ms_serial_callbacks {
+            on_data: Some(data_trampoline),
+            on_event: Some(event_trampoline),
+        };
+        let rc = unsafe {
+            ms_serial_port_start(self.handle, callbacks, Arc::as_ptr(&state) as *mut c_void)
+        };
+        if rc != 0 {
+            return Err(rc);
+        }
+        self.callbacks = Some(state);
+        Ok(())
+    }
+
+    pub fn stop(&mut self) {
+        unsafe { ms_serial_port_stop(self.handle) };
+        self.callbacks = None;
+    }
+
+    pub fn write(&mut self, data: &[u8]) -> Result<usize, i32> {
+        let rc = unsafe { ms_serial_port_write(self.handle, data.as_ptr(), data.len()) };
+        if rc < 0 {
+            return Err(rc as i32);
+        }
+        Ok(rc as usize)
+    }
+}
+
+impl Drop for SerialPort {
+    fn drop(&mut self) {
+        unsafe {
+            ms_serial_port_stop(self.handle);
+            ms_serial_port_close(self.handle);
+        }
+    }
+}
+
+pub fn default_config() -> ms_serial_config {
+    ms_serial_config {
+        baud_rate: 115200,
+        data_bits: 8,
+        stop_bits: 1,
+        parity: ms_serial_parity_MS_SERIAL_PARITY_NONE,
+        flow_control: ms_serial_flow_control_MS_SERIAL_FLOW_NONE,
+        rx_buffer_size: 1 << 15,
+        tx_buffer_size: 1 << 15,
+        read_timeout_ms: 100,
+        write_timeout_ms: 100,
+    }
+}
+
+pub fn list_serial_ports() -> Result<Vec<SerialDevice>, i32> {
+    let mut raw_list: *mut ms_serial_port_info = ptr::null_mut();
+    let mut count: usize = 0;
+    let rc = unsafe { ms_serial_port_enumerate(&mut raw_list, &mut count) };
+    if rc != 0 {
+        return Err(rc);
+    }
+    let slice = unsafe { slice::from_raw_parts(raw_list, count) };
+    let mut devices = Vec::with_capacity(slice.len());
+    for item in slice {
+        let path = unsafe { CStr::from_ptr(item.path.as_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+        let description = unsafe { CStr::from_ptr(item.description.as_ptr()) }
+            .to_string_lossy()
+            .into_owned();
+        devices.push(SerialDevice { path, description });
+    }
+    unsafe { ms_serial_port_list_free(raw_list, count) };
+    Ok(devices)
+}

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -1,0 +1,194 @@
+mod core;
+
+use crate::core::{SerialDevice, SerialPort, default_config, list_serial_ports};
+use eframe::egui;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::time::Instant;
+
+#[derive(Debug)]
+enum UiMessage {
+    Data(String),
+    Event(String),
+}
+
+struct MicroSerialApp {
+    ports: Vec<SerialDevice>,
+    selected: Option<usize>,
+    session: Option<SerialSession>,
+    log: Vec<String>,
+    input: String,
+    last_refresh: Instant,
+}
+
+struct SerialSession {
+    port: SerialPort,
+    rx: Receiver<UiMessage>,
+    _tx: Sender<UiMessage>,
+}
+
+impl SerialSession {
+    fn new(mut port: SerialPort) -> Result<Self, String> {
+        let (tx, rx) = mpsc::channel();
+        let data_tx = tx.clone();
+        port.configure(&default_config())
+            .map_err(|e| format!("configure error {e}"))?;
+        port.start(
+            move |bytes| {
+                if let Ok(text) = String::from_utf8(bytes.to_vec()) {
+                    let _ = data_tx.send(UiMessage::Data(text));
+                } else {
+                    let hex = bytes
+                        .iter()
+                        .map(|b| format!("{b:02X}"))
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    let _ = data_tx.send(UiMessage::Data(format!("[{hex}]")));
+                }
+            },
+            move |code, message| {
+                let _ = tx.send(UiMessage::Event(format!("event {code}: {message}")));
+            },
+        )
+        .map_err(|e| format!("start error {e}"))?;
+        Ok(Self { port, rx, _tx: tx })
+    }
+
+    fn write(&mut self, text: &str) -> Result<(), String> {
+        let payload = text.as_bytes();
+        let written = self
+            .port
+            .write(payload)
+            .map_err(|e| format!("write failed {e}"))?;
+        if written != payload.len() {
+            Err("write truncated".to_string())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for SerialSession {
+    fn drop(&mut self) {
+        self.port.stop();
+    }
+}
+
+impl MicroSerialApp {
+    fn new() -> Self {
+        let ports = list_serial_ports().unwrap_or_default();
+        Self {
+            ports,
+            selected: None,
+            session: None,
+            log: Vec::new(),
+            input: String::new(),
+            last_refresh: Instant::now(),
+        }
+    }
+
+    fn refresh_ports(&mut self) {
+        if let Ok(ports) = list_serial_ports() {
+            self.ports = ports;
+            self.last_refresh = Instant::now();
+        }
+    }
+
+    fn poll_messages(&mut self) {
+        if let Some(session) = &self.session {
+            while let Ok(msg) = session.rx.try_recv() {
+                match msg {
+                    UiMessage::Data(text) => self.log.push(format!("RX: {text}")),
+                    UiMessage::Event(text) => self.log.push(format!("{text}")),
+                }
+            }
+        }
+    }
+}
+
+impl eframe::App for MicroSerialApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.poll_messages();
+        egui::TopBottomPanel::top("top").show(ctx, |ui| {
+            ui.heading("MicroSerial");
+            if ui.button("Refresh ports").clicked() {
+                self.refresh_ports();
+            }
+            ui.label(format!("Ports discovered: {}", self.ports.len()));
+        });
+
+        egui::SidePanel::left("ports").show(ctx, |ui| {
+            ui.heading("Ports");
+            for (idx, port) in self.ports.iter().enumerate() {
+                let label = format!("{} — {}", port.path, port.description);
+                if ui
+                    .selectable_label(self.selected == Some(idx), label)
+                    .clicked()
+                {
+                    self.selected = Some(idx);
+                }
+            }
+            if ui.button("Open").clicked() {
+                if let Some(idx) = self.selected {
+                    self.session = None;
+                    let path = self.ports[idx].path.clone();
+                    match SerialPort::open(&path) {
+                        Ok(port) => match SerialSession::new(port) {
+                            Ok(session) => {
+                                self.log.push(format!("Opened {path}"));
+                                self.session = Some(session);
+                            }
+                            Err(err) => {
+                                self.log.push(format!("Failed start {err}"));
+                            }
+                        },
+                        Err(code) => {
+                            self.log.push(format!("Open failed ({code})"));
+                        }
+                    }
+                }
+            }
+            if ui.button("Close").clicked() {
+                self.session = None;
+            }
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Console");
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                for entry in &self.log {
+                    ui.label(entry);
+                }
+            });
+            ui.separator();
+            ui.horizontal(|ui| {
+                ui.label("Send");
+                let response = ui.text_edit_singleline(&mut self.input);
+                if ui.button("Send").clicked()
+                    || response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                {
+                    if let Some(session) = self.session.as_mut() {
+                        if !self.input.is_empty() {
+                            if let Err(err) = session.write(&self.input) {
+                                self.log.push(err);
+                            } else {
+                                self.log.push(format!("TX: {}", self.input));
+                            }
+                            self.input.clear();
+                        }
+                    }
+                }
+            });
+        });
+        ctx.request_repaint_after(std::time::Duration::from_millis(16));
+    }
+}
+
+fn main() -> eframe::Result {
+    env_logger::init();
+    let options = eframe::NativeOptions::default();
+    eframe::run_native(
+        "MicroSerial",
+        options,
+        Box::new(|_| Box::new(MicroSerialApp::new())),
+    )
+}

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,5 @@
+# Plugin Development
+
+MicroSerial exposes a stable C ABI for protocol and decoder plugins (`core/include/MicroSerial/plugins/plugin_abi.h`). Plugins are shared objects that export `ms_plugin_query` returning a descriptor with metadata and function pointers.
+
+Future releases will ship a loader that scans `plugins/` at runtime, validates ABI versions, and wires plugin output into GUI views. Authoring guide coming soon.

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BUILD_DIR="${ROOT_DIR}/build/core"
+
+cmake -S "${ROOT_DIR}/core" -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE=Release
+cmake --build "${BUILD_DIR}" --config Release
+
+cargo build --manifest-path "${ROOT_DIR}/gui/Cargo.toml"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+# Testing Strategy
+
+* **Unit tests (C)** – Added via CTest under `core/tests/`, covering pseudo-terminal loopback flows.
+* **Rust unit/integration tests** – To be added for GUI state reducers and FFI wrappers (`cargo test`).
+* **Fuzzing** – Planned for protocol parsers (libFuzzer + honggfuzz harness).
+* **Benchmarking** – Dedicated suite will measure throughput and latency using loopback harnesses and high-resolution timers.


### PR DESCRIPTION
## Summary
- establish the C11 core with async serial sessions, ring buffers, OS discovery, and a stable header-per-function API surface
- add unit coverage via a pseudo-terminal loopback test and wire up CMake build tooling with security-focused defaults
- scaffold the Rust/egui desktop client that builds the C core via CMake, provides safe FFI bindings, enumerates ports, and streams RX/TX activity in the UI alongside new architecture and build docs

## Testing
- `cmake -S core -B build/core -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build/core --config Release`
- `ctest --test-dir build/core`
- `cargo build --manifest-path gui/Cargo.toml` *(fails: crates.io index unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6b8fe2a4832b8d549aadd5e1c420