### PR TITLE
Fix GUI build on Linux and document platform setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,72 @@ tests/     # Integration & fuzz harness entrypoints
 
 The GUI auto-discovers serial ports, opens a dedicated async session, and renders RX/TX streams in real time. For loopback demos without hardware, pair pseudo-terminals with `socat` or rely on the built-in integration test.
 
+## Platform Setup & Detailed Build Instructions
+
+### Linux
+
+1. **Install prerequisites** (example for Debian/Ubuntu):
+   ```bash
+   sudo apt update
+   sudo apt install build-essential cmake ninja-build pkg-config libudev-dev libclang-dev
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+   source "$HOME/.cargo/env"
+   ```
+   *CMake* drives the C11 core build, `libclang` powers the Rust FFI bindings, and `pkg-config`/`libudev` provide serial device discovery headers.
+2. **Build the C core:**
+   ```bash
+   cmake -S core -B build/core -DCMAKE_BUILD_TYPE=Release
+   cmake --build build/core --config Release
+   ctest --test-dir build/core
+   ```
+3. **Compile the Rust GUI:**
+   ```bash
+   cargo build --manifest-path gui/Cargo.toml
+   ```
+   The GUI crate regenerates bindings and links against the freshly built `microserial_core` static library. The `eframe` dependency enables both Wayland and X11 window backends so either display server is supported out of the box.
+4. **Run it:** `cargo run --manifest-path gui/Cargo.toml`
+
+### macOS
+
+1. **Install developer tools:**
+   ```bash
+   xcode-select --install
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   brew install cmake ninja pkg-config llvm rustup
+   rustup-init -y
+   source "$HOME/.cargo/env"
+   ```
+   Homebrew supplies a modern Clang toolchain used by both the C core and `bindgen`.
+2. **Export LLVM for bindgen** (needed when Homebrew installs LLVM outside of `/usr/bin`):
+   ```bash
+   export LIBCLANG_PATH="$(brew --prefix llvm)/lib"
+   export PATH="$(brew --prefix llvm)/bin:$PATH"
+   ```
+3. **Build core + GUI:** reuse the same `cmake` and `cargo` commands as on Linux. `./scripts/build_all.sh` also works inside a POSIX shell on macOS.
+4. **Run the app:** `cargo run --manifest-path gui/Cargo.toml`
+
+### Windows (MSVC toolchain)
+
+1. **Install dependencies:**
+   * [Visual Studio Build Tools 2022](https://visualstudio.microsoft.com/downloads/) with the “Desktop development with C++” workload.
+   * [CMake](https://cmake.org/download/), [Ninja](https://github.com/ninja-build/ninja/releases), and the [LLVM](https://releases.llvm.org/download.html) binaries.
+   * [rustup-init.exe](https://win.rustup.rs/) to install the stable Rust toolchain (`rustup default stable`).
+2. **Open the “x64 Native Tools Command Prompt for VS 2022”** so MSVC, CMake, and Ninja are on `PATH`. If LLVM is installed in a custom directory, set `LIBCLANG_PATH=C:\\Program Files\\LLVM\\bin` before building.
+3. **Configure and build the core:**
+   ```powershell
+   cmake -S core -B build\core -G "Ninja" -DCMAKE_BUILD_TYPE=Release
+   cmake --build build\core --config Release
+   ctest --test-dir build\core
+   ```
+4. **Build the GUI:**
+   ```powershell
+   cargo build --manifest-path gui/Cargo.toml
+   ```
+   The Rust build script invokes CMake automatically, links against the MSVC-built static core, and bundles the resulting executable under `gui\target\debug\microserial_gui.exe` (or `...\release\`).
+5. **Run the GUI:** `cargo run --manifest-path gui/Cargo.toml`
+
+> **Tip:** On any platform you can rerun everything in one shot via `./scripts/build_all.sh` (or `bash scripts/build_all.sh` on Windows when using Git Bash).
+
 ## Documentation
 
 * [Design Document](docs/design.md)

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-eframe = { version = "0.26", default-features = false, features = ["wgpu"] }
+eframe = { version = "0.26", default-features = false, features = ["wgpu", "wayland", "x11"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"


### PR DESCRIPTION
## Summary
- enable the eframe Wayland and X11 backends so the GUI builds against winit on Linux
- expand the README with platform-specific setup and build instructions for Linux, macOS, and Windows

## Testing
- ./scripts/build_all.sh *(fails: crates.io index blocked by 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68cd05a99b24832bb836ed763428d0d9