### PR TITLE
Fix GUI build configuration and bindings

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -69,6 +69,18 @@ target_include_directories(microserial_core
 
 target_link_libraries(microserial_core PUBLIC pthread)
 
+include(GNUInstallDirs)
+install(
+    TARGETS microserial_core
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(
+    DIRECTORY include/MicroSerial
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
 include(CTest)
 if(BUILD_TESTING)
     add_subdirectory(tests)

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -4,12 +4,17 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-eframe = { version = "0.26", default-features = false, features = ["wgpu", "wayland", "x11"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 libc = "0.2"
 env_logger = "0.11"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+eframe = { version = "0.26", default-features = false, features = ["wgpu", "wayland", "x11"] }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+eframe = { version = "0.26", default-features = false, features = ["wgpu"] }
 
 [build-dependencies]
 cmake = "0.1"

--- a/gui/src/core.rs
+++ b/gui/src/core.rs
@@ -26,8 +26,8 @@ unsafe extern "C" fn data_trampoline(data: *const u8, length: usize, user_data: 
     if data.is_null() || user_data.is_null() {
         return;
     }
-    let slice = slice::from_raw_parts(data, length);
-    let state = &*(user_data as *const CallbackState);
+    let slice = unsafe { slice::from_raw_parts(data, length) };
+    let state = unsafe { &*(user_data as *const CallbackState) };
     if let Ok(mut guard) = state.on_data.lock() {
         (guard.as_mut())(slice);
     }
@@ -37,9 +37,9 @@ unsafe extern "C" fn event_trampoline(code: c_int, message: *const c_char, user_
     if user_data.is_null() {
         return;
     }
-    let state = &*(user_data as *const CallbackState);
+    let state = unsafe { &*(user_data as *const CallbackState) };
     let msg = if !message.is_null() {
-        CStr::from_ptr(message).to_string_lossy().to_string()
+        unsafe { CStr::from_ptr(message) }.to_string_lossy().to_string()
     } else {
         String::new()
     };

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -30,6 +30,7 @@ impl SerialSession {
     fn new(mut port: SerialPort) -> Result<Self, String> {
         let (tx, rx) = mpsc::channel();
         let data_tx = tx.clone();
+        let event_tx = tx.clone();
         port.configure(&default_config())
             .map_err(|e| format!("configure error {e}"))?;
         port.start(
@@ -46,7 +47,7 @@ impl SerialSession {
                 }
             },
             move |code, message| {
-                let _ = tx.send(UiMessage::Event(format!("event {code}: {message}")));
+                let _ = event_tx.send(UiMessage::Event(format!("event {code}: {message}")));
             },
         )
         .map_err(|e| format!("start error {e}"))?;
@@ -183,7 +184,7 @@ impl eframe::App for MicroSerialApp {
     }
 }
 
-fn main() -> eframe::Result {
+fn main() -> eframe::Result<()> {
     env_logger::init();
     let options = eframe::NativeOptions::default();
     eframe::run_native(


### PR DESCRIPTION
## Summary
- make the GUI crate enable the appropriate eframe/winit features per-target so Linux builds pull in X11/Wayland support without breaking other platforms
- add installation rules for the core CMake project so the build script can link against the staged static library and headers
- adjust the GUI build script and Rust sources to generate Rust-2024 compatible bindings and clean up ownership issues in the session code

## Testing
- ./scripts/build_all.sh

------
https://chatgpt.com/codex/tasks/task_e_68cd086d0844832b932f9286f941c9d4