### PR TITLE
Add software renderer fallback

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -407,6 +407,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +722,10 @@ dependencies = [
  "egui",
  "egui-wgpu",
  "egui-winit",
+ "egui_glow",
+ "glow",
+ "glutin",
+ "glutin-winit",
  "image",
  "js-sys",
  "log",
@@ -720,6 +733,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pollster",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "static_assertions",
  "thiserror",
@@ -791,6 +805,21 @@ dependencies = [
  "image",
  "log",
  "serde",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0e5d975f3c86edc3d35b1db88bb27c15dde7c55d3b5af164968ab5ede3f44ca"
+dependencies = [
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "memoffset",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1030,6 +1059,62 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg_aliases 0.1.1",
+ "cgl",
+ "core-foundation",
+ "dispatch",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "icrate",
+ "libloading 0.8.8",
+ "objc2 0.4.1",
+ "once_cell",
+ "raw-window-handle 0.5.2",
+ "wayland-sys",
+ "windows-sys 0.48.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735"
+dependencies = [
+ "cfg_aliases 0.1.1",
+ "glutin",
+ "raw-window-handle 0.5.2",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
 ]
 
 [[package]]
@@ -1510,6 +1595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metal"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1691,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "thiserror",
 ]
@@ -3319,6 +3414,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "redox_syscall 0.3.5",
  "rustix 0.38.44",

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -6,7 +6,7 @@ links = "microserial_core"
 
 [dependencies]
 directories = "5"
-eframe = { version = "0.27", default-features = false, features = ["wgpu"] }
+eframe = { version = "0.27", default-features = false, features = ["wgpu", "glow"] }
 egui_extras = { version = "0.27", default-features = false, features = ["image"] }
 egui-wgpu = { version = "0.27", default-features = false }
 env_logger = "0.11"

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -753,7 +753,7 @@ impl eframe::App for MicroSerialApp {
         ctx.request_repaint_after(Duration::from_millis(16));
     }
 
-    fn on_exit(&mut self) {
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
         let _ = self.settings.save();
     }
 }

--- a/gui/src/renderer.rs
+++ b/gui/src/renderer.rs
@@ -13,10 +13,37 @@ pub struct RendererSelection {
 }
 
 impl RendererSelection {
-    fn new(attempt: usize, attempt_label: &'static str, diagnostics: RendererDiagnostics) -> Self {
+    fn new_wgpu(
+        attempt: usize,
+        attempt_label: &'static str,
+        diagnostics: RendererDiagnostics,
+    ) -> Self {
         let mut options = eframe::NativeOptions::default();
         options.renderer = eframe::Renderer::Wgpu;
         options.hardware_acceleration = eframe::HardwareAcceleration::Preferred;
+        Self {
+            attempt,
+            attempt_label,
+            options,
+            diagnostics,
+        }
+    }
+
+    fn new_glow(
+        attempt: usize,
+        attempt_label: &'static str,
+        mut diagnostics: RendererDiagnostics,
+    ) -> Self {
+        diagnostics.backend = "glow".to_string();
+        diagnostics.backend_details = Some("Software renderer (glow fallback)".to_string());
+        diagnostics.adapter_type = Some("Cpu".to_string());
+        diagnostics.adapter_name = diagnostics
+            .adapter_name
+            .or_else(|| Some("Software Renderer".to_string()));
+
+        let mut options = eframe::NativeOptions::default();
+        options.renderer = eframe::Renderer::Glow;
+        options.hardware_acceleration = eframe::HardwareAcceleration::Off;
         Self {
             attempt,
             attempt_label,
@@ -123,6 +150,7 @@ impl LaunchConfig {
         attempts.push(Attempt::gl_software());
         #[cfg(target_os = "macos")]
         attempts.push(Attempt::metal());
+        attempts.push(Attempt::glow_software());
         attempts
     }
 }
@@ -132,15 +160,20 @@ fn env_flag(key: &str) -> bool {
 }
 
 #[derive(Clone, Copy)]
-struct Attempt {
-    label: &'static str,
-    backend: Option<&'static str>,
-    enforce_software: bool,
+enum Attempt {
+    Wgpu {
+        label: &'static str,
+        backend: Option<&'static str>,
+        enforce_software: bool,
+    },
+    GlowSoftware {
+        label: &'static str,
+    },
 }
 
 impl Attempt {
     fn system_default() -> Self {
-        Self {
+        Self::Wgpu {
             label: "system default",
             backend: None,
             enforce_software: false,
@@ -148,7 +181,7 @@ impl Attempt {
     }
 
     fn vulkan() -> Self {
-        Self {
+        Self::Wgpu {
             label: "WGPU_BACKEND=vulkan",
             backend: Some("vulkan"),
             enforce_software: false,
@@ -156,7 +189,7 @@ impl Attempt {
     }
 
     fn gl_software() -> Self {
-        Self {
+        Self::Wgpu {
             label: "WGPU_BACKEND=gl (software)",
             backend: Some("gl"),
             enforce_software: true,
@@ -165,44 +198,85 @@ impl Attempt {
 
     #[cfg(target_os = "macos")]
     fn metal() -> Self {
-        Self {
+        Self::Wgpu {
             label: "WGPU_BACKEND=metal",
             backend: Some("metal"),
             enforce_software: false,
         }
     }
 
-    fn apply(&self, launch: &LaunchConfig, diagnostics: &mut RendererDiagnostics) {
-        match (&self.backend, &launch.original_backend) {
-            (Some(value), _) => unsafe { env::set_var("WGPU_BACKEND", value) },
-            (None, Some(original)) => unsafe { env::set_var("WGPU_BACKEND", original) },
-            (None, None) => unsafe { env::remove_var("WGPU_BACKEND") },
+    fn glow_software() -> Self {
+        Self::GlowSoftware {
+            label: "software glow",
         }
+    }
 
-        let software = launch.force_software || self.enforce_software;
-        diagnostics.software_backend = software;
-        if software {
-            unsafe {
-                env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
-                env::set_var("WGPU_POWER_PREF", "low_power");
-            }
-        } else {
-            if let Some(original) = &launch.original_libgl {
-                unsafe { env::set_var("LIBGL_ALWAYS_SOFTWARE", original) };
-            } else {
-                unsafe { env::remove_var("LIBGL_ALWAYS_SOFTWARE") };
-            }
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Wgpu { label, .. } | Self::GlowSoftware { label } => label,
+        }
+    }
 
-            if let Some(original) = &launch.original_power_pref {
-                unsafe { env::set_var("WGPU_POWER_PREF", original) };
-            } else {
-                unsafe { env::remove_var("WGPU_POWER_PREF") };
+    fn apply(&self, launch: &LaunchConfig, diagnostics: &mut RendererDiagnostics) {
+        match self {
+            Self::Wgpu {
+                backend,
+                enforce_software,
+                ..
+            } => {
+                match (backend, &launch.original_backend) {
+                    (Some(value), _) => unsafe { env::set_var("WGPU_BACKEND", value) },
+                    (None, Some(original)) => unsafe { env::set_var("WGPU_BACKEND", original) },
+                    (None, None) => unsafe { env::remove_var("WGPU_BACKEND") },
+                }
+
+                let software = launch.force_software || *enforce_software;
+                diagnostics.software_backend = software;
+                if software {
+                    unsafe {
+                        env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
+                        env::set_var("WGPU_POWER_PREF", "low_power");
+                    }
+                } else {
+                    if let Some(original) = &launch.original_libgl {
+                        unsafe { env::set_var("LIBGL_ALWAYS_SOFTWARE", original) };
+                    } else {
+                        unsafe { env::remove_var("LIBGL_ALWAYS_SOFTWARE") };
+                    }
+
+                    if let Some(original) = &launch.original_power_pref {
+                        unsafe { env::set_var("WGPU_POWER_PREF", original) };
+                    } else {
+                        unsafe { env::remove_var("WGPU_POWER_PREF") };
+                    }
+                }
+            }
+            Self::GlowSoftware { .. } => {
+                diagnostics.software_backend = true;
+                if let Some(original) = &launch.original_backend {
+                    unsafe { env::set_var("WGPU_BACKEND", original) };
+                } else {
+                    unsafe { env::remove_var("WGPU_BACKEND") };
+                }
+                unsafe {
+                    env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
+                    env::remove_var("WGPU_POWER_PREF");
+                }
             }
         }
     }
 
     fn prefers_low_power(&self, launch: &LaunchConfig) -> bool {
-        launch.force_software || self.enforce_software
+        match self {
+            Self::Wgpu {
+                enforce_software, ..
+            } => launch.force_software || *enforce_software,
+            Self::GlowSoftware { .. } => true,
+        }
+    }
+
+    fn is_wgpu(&self) -> bool {
+        matches!(self, Self::Wgpu { .. })
     }
 }
 
@@ -251,24 +325,31 @@ pub fn detect(launch: &LaunchConfig, start_attempt: usize) -> Result<RendererSel
 
         attempt.apply(launch, &mut current);
 
-        let prefer_low_power = attempt.prefers_low_power(launch);
-        match probe_wgpu(prefer_low_power) {
-            Ok(info) => {
-                current.backend = format!("{:?}", info.backend);
-                current.adapter_name = Some(info.name.clone());
-                current.adapter_type = Some(format!("{:?}", info.device_type));
-                current.backend_details = Some(format!("Driver: {}", info.driver));
-                if info.device_type == wgpu::DeviceType::Cpu {
-                    current.software_backend = true;
+        if attempt.is_wgpu() {
+            let prefer_low_power = attempt.prefers_low_power(launch);
+            match probe_wgpu(prefer_low_power) {
+                Ok(info) => {
+                    current.backend = format!("{:?}", info.backend);
+                    current.adapter_name = Some(info.name.clone());
+                    current.adapter_type = Some(format!("{:?}", info.device_type));
+                    current.backend_details = Some(format!("Driver: {}", info.driver));
+                    if info.device_type == wgpu::DeviceType::Cpu {
+                        current.software_backend = true;
+                    }
+                    if !failures.is_empty() {
+                        current.failure_reason = Some(failures.join(" -> "));
+                    }
+                    return Ok(RendererSelection::new_wgpu(index, attempt.label(), current));
                 }
-                if !failures.is_empty() {
-                    current.failure_reason = Some(failures.join(" -> "));
+                Err(err) => {
+                    failures.push(format!("{}: {}", attempt.label(), err));
                 }
-                return Ok(RendererSelection::new(index, attempt.label, current));
             }
-            Err(err) => {
-                failures.push(format!("{}: {}", attempt.label, err));
+        } else {
+            if !failures.is_empty() {
+                current.failure_reason = Some(failures.join(" -> "));
             }
+            return Ok(RendererSelection::new_glow(index, attempt.label(), current));
         }
     }
 


### PR DESCRIPTION
## Summary
- add a glow-based software renderer fallback so the GUI can run without GPU acceleration
- enable the eframe glow backend and adjust the app shutdown hook for the new renderer stack

## Testing
- cargo test --manifest-path gui/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68d199a74f00832b9eac13806834b604