### PR TITLE
Handle wgpu fallback on non-Windows hosts

### DIFF
--- a/docs/gui/rendering.md
+++ b/docs/gui/rendering.md
@@ -34,7 +34,7 @@ The GUI boots through a layered renderer selection pipeline that favours hardwar
 
 1. **Launch configuration** collects signals from environment variables, command-line flags, and persisted settings. `MICROSERIAL_FORCE_SOFTWARE=1`, the CLI `--force-software` flag, or the in-app toggle call `LaunchConfig::enable_force_software`, exporting `LIBGL_ALWAYS_SOFTWARE=1` and `WGPU_POWER_PREF=low_power` before any adapter probe runs.
 2. **`renderer::detect`** records the active compositor (Wayland or X11) and attempts to obtain a `wgpu` adapter while iterating through the fallback chain. Each step sets `WGPU_BACKEND`/`LIBGL_ALWAYS_SOFTWARE` as required before probing.
-3. **Runtime fallback**: if `eframe::run_native` still fails to build a surface with the chosen backend, the launcher advances to the next attempt in the chain without ever touching glutin.
+3. **Runtime fallback**: if `eframe::run_native` still fails to build a surface with the chosen backend, the launcher advances to the next attempt in the chain without ever touching glutin. On non-Windows platforms the "software" step relies on Mesa's llvmpipe/Zink stack, so the launcher avoids requesting wgpu's explicit fallback adapter (which only exists on Windows and would prevent the Mesa adapters from being enumerated).
 
 ## Rationale
 


### PR DESCRIPTION
## Summary
- avoid requesting wgpu's fallback adapter on non-Windows platforms so Mesa software adapters can still be discovered
- document how the software fallback differs between Windows and Unix hosts

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d22924634c832ba52d6fdca44968a3