### PR TITLE
Add OpenGL glow fallback when wgpu fails

### DIFF
--- a/docs/gui/rendering.md
+++ b/docs/gui/rendering.md
@@ -17,15 +17,16 @@ The GUI boots through a layered renderer selection pipeline that favours hardwar
                   │
                   ▼
      ┌────────────────────────────┐
-     │  wgpu attempt sequence     │
-     │  1. system defaults        │
+     │  renderer attempt sequence │
+     │  1. system defaults (wgpu) │
      │  2. WGPU_BACKEND=vulkan    │
      │  3. WGPU_BACKEND=gl + SW   │
-     │  4. WGPU_BACKEND=metal (*) │
+     │  4. eframe glow (OpenGL)   │
+     │  5. WGPU_BACKEND=metal (*) │
      └────────────────────────────┘
                   │
                   ▼
-          eframe::run_native (WGPU)
+          eframe::run_native (wgpu/glow)
 
 (*) macOS only
 ```
@@ -34,13 +35,13 @@ The GUI boots through a layered renderer selection pipeline that favours hardwar
 
 1. **Launch configuration** collects signals from environment variables, command-line flags, and persisted settings. `MICROSERIAL_FORCE_SOFTWARE=1`, the CLI `--force-software` flag, or the in-app toggle call `LaunchConfig::enable_force_software`, exporting `LIBGL_ALWAYS_SOFTWARE=1` and `WGPU_POWER_PREF=low_power` before any adapter probe runs.
 2. **`renderer::detect`** records the active compositor (Wayland or X11) and attempts to obtain a `wgpu` adapter while iterating through the fallback chain. Each step sets `WGPU_BACKEND`/`LIBGL_ALWAYS_SOFTWARE` as required before probing.
-3. **Runtime fallback**: if `eframe::run_native` still fails to build a surface with the chosen backend, the launcher advances to the next attempt in the chain without ever touching glutin.
+3. **Runtime fallback**: if `eframe::run_native` still fails to build a surface with the chosen backend, the launcher advances to the next attempt in the chain without ever touching glutin. On non-Windows platforms the "software" steps rely on Mesa's llvmpipe/Zink stack or pure OpenGL contexts, so the launcher avoids requesting wgpu's explicit fallback adapter (which only exists on Windows and would prevent the Mesa adapters from being enumerated) and finally falls back to `eframe`'s built-in `glow` renderer.
 
 ## Rationale
 
 - **Predictability:** All renderer decisions are centralised in `renderer.rs`, making it trivial to unit-test the decision matrix and to expose the chosen backend via the diagnostics panel.
 - **Graceful failure:** The retry loop isolates GPU driver crashes from the rest of the application. Users receive a working UI instead of a crash, and diagnostics clearly document the fallback path.
-- **Cross-platform compliance:** The approach works across Wayland/X11 on Linux and Metal on macOS via the pure `wgpu` backend, avoiding glutin/GL entirely.
+- **Cross-platform compliance:** The approach works across Wayland/X11 on Linux and Metal on macOS via the pure `wgpu` backend when available, while retaining an OpenGL escape hatch (`glow`) for environments where EGL/DRI access is blocked (e.g. VMs, containers).
 - **Operator control:** Environment toggles (`MICROSERIAL_FORCE_SOFTWARE`, `LIBGL_ALWAYS_SOFTWARE`, `WGPU_BACKEND`) and the in-app switch empower operators and CI to pick a deterministic backend. Headless/CI jobs run with software rendering forced, guaranteeing reproducible results.
 
 ## Diagnostics & telemetry

--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -407,6 +407,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +722,10 @@ dependencies = [
  "egui",
  "egui-wgpu",
  "egui-winit",
+ "egui_glow",
+ "glow",
+ "glutin",
+ "glutin-winit",
  "image",
  "js-sys",
  "log",
@@ -720,6 +733,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pollster",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "static_assertions",
  "thiserror",
@@ -791,6 +805,21 @@ dependencies = [
  "image",
  "log",
  "serde",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0e5d975f3c86edc3d35b1db88bb27c15dde7c55d3b5af164968ab5ede3f44ca"
+dependencies = [
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "memoffset",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1030,6 +1059,62 @@ dependencies = [
  "slotmap",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg_aliases 0.1.1",
+ "cgl",
+ "core-foundation",
+ "dispatch",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "icrate",
+ "libloading 0.8.8",
+ "objc2 0.4.1",
+ "once_cell",
+ "raw-window-handle 0.5.2",
+ "wayland-sys",
+ "windows-sys 0.48.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735"
+dependencies = [
+ "cfg_aliases 0.1.1",
+ "glutin",
+ "raw-window-handle 0.5.2",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
 ]
 
 [[package]]
@@ -1510,6 +1595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metal"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1691,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "thiserror",
 ]
@@ -3319,6 +3414,7 @@ dependencies = [
  "once_cell",
  "orbclient",
  "percent-encoding",
+ "raw-window-handle 0.5.2",
  "raw-window-handle 0.6.2",
  "redox_syscall 0.3.5",
  "rustix 0.38.44",

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -6,7 +6,7 @@ links = "microserial_core"
 
 [dependencies]
 directories = "5"
-eframe = { version = "0.27", default-features = false, features = ["wgpu"] }
+eframe = { version = "0.27", default-features = false, features = ["wgpu", "glow"] }
 egui_extras = { version = "0.27", default-features = false, features = ["image"] }
 egui-wgpu = { version = "0.27", default-features = false }
 env_logger = "0.11"

--- a/gui/src/app.rs
+++ b/gui/src/app.rs
@@ -753,7 +753,7 @@ impl eframe::App for MicroSerialApp {
         ctx.request_repaint_after(Duration::from_millis(16));
     }
 
-    fn on_exit(&mut self) {
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
         let _ = self.settings.save();
     }
 }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -80,12 +80,8 @@ fn main() -> eframe::Result<()> {
 fn run_with_selection(selection: &RendererSelection, settings: &Settings) -> eframe::Result<()> {
     let diagnostics = selection.diagnostics.clone();
     let app_settings = settings.clone();
-    let mut base_options = selection.options.clone();
-    base_options.follow_system_theme = false;
-    let native_options = eframe::NativeOptions {
-        renderer: eframe::Renderer::Wgpu,
-        ..base_options
-    };
+    let mut native_options = selection.options.clone();
+    native_options.follow_system_theme = false;
     eframe::run_native(
         "MicroSerial",
         native_options,

--- a/gui/src/renderer.rs
+++ b/gui/src/renderer.rs
@@ -32,6 +32,27 @@ impl RendererSelection {
             diagnostics,
         }
     }
+
+    fn new_glow(
+        attempt: usize,
+        attempt_label: &'static str,
+        mut diagnostics: RendererDiagnostics,
+    ) -> Self {
+        diagnostics.backend = String::from("glow");
+        let mut options = eframe::NativeOptions::default();
+        options.renderer = eframe::Renderer::Glow;
+        if diagnostics.software_backend {
+            options.hardware_acceleration = eframe::HardwareAcceleration::Off;
+        } else {
+            options.hardware_acceleration = eframe::HardwareAcceleration::Preferred;
+        }
+        Self {
+            attempt,
+            attempt_label,
+            options,
+            diagnostics,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -129,6 +150,7 @@ impl LaunchConfig {
     fn fallback_plan(&self) -> Vec<Attempt> {
         let mut attempts = vec![Attempt::system_default(), Attempt::vulkan()];
         attempts.push(Attempt::gl_software());
+        attempts.push(Attempt::glow());
         #[cfg(target_os = "macos")]
         attempts.push(Attempt::metal());
         attempts
@@ -144,6 +166,10 @@ enum Attempt {
     Wgpu {
         label: &'static str,
         backend: Option<&'static str>,
+        enforce_software: bool,
+    },
+    Glow {
+        label: &'static str,
         enforce_software: bool,
     },
 }
@@ -173,6 +199,13 @@ impl Attempt {
         }
     }
 
+    fn glow() -> Self {
+        Self::Glow {
+            label: "eframe glow (OpenGL)",
+            enforce_software: true,
+        }
+    }
+
     #[cfg(target_os = "macos")]
     fn metal() -> Self {
         Self::Wgpu {
@@ -185,6 +218,7 @@ impl Attempt {
     fn label(&self) -> &'static str {
         match self {
             Self::Wgpu { label, .. } => label,
+            Self::Glow { label, .. } => label,
         }
     }
 
@@ -222,10 +256,41 @@ impl Attempt {
                     }
                 }
 
-                AttemptConfig {
+                AttemptConfig::Wgpu {
                     backends: backend_mask(*backend),
                     force_fallback: software,
                 }
+            }
+            Self::Glow {
+                enforce_software, ..
+            } => {
+                match &launch.original_backend {
+                    Some(original) => unsafe { env::set_var("WGPU_BACKEND", original) },
+                    None => unsafe { env::remove_var("WGPU_BACKEND") },
+                }
+
+                let software = launch.force_software || *enforce_software;
+                diagnostics.software_backend = software;
+                if software {
+                    unsafe {
+                        env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
+                        env::set_var("WGPU_POWER_PREF", "low_power");
+                    }
+                } else {
+                    if let Some(original) = &launch.original_libgl {
+                        unsafe { env::set_var("LIBGL_ALWAYS_SOFTWARE", original) };
+                    } else {
+                        unsafe { env::remove_var("LIBGL_ALWAYS_SOFTWARE") };
+                    }
+
+                    if let Some(original) = &launch.original_power_pref {
+                        unsafe { env::set_var("WGPU_POWER_PREF", original) };
+                    } else {
+                        unsafe { env::remove_var("WGPU_POWER_PREF") };
+                    }
+                }
+
+                AttemptConfig::Glow { software }
             }
         }
     }
@@ -235,14 +300,22 @@ impl Attempt {
             Self::Wgpu {
                 enforce_software, ..
             } => launch.force_software || *enforce_software,
+            Self::Glow {
+                enforce_software, ..
+            } => launch.force_software || *enforce_software,
         }
     }
 }
 
 #[derive(Clone, Copy)]
-struct AttemptConfig {
-    backends: wgpu::Backends,
-    force_fallback: bool,
+enum AttemptConfig {
+    Wgpu {
+        backends: wgpu::Backends,
+        force_fallback: bool,
+    },
+    Glow {
+        software: bool,
+    },
 }
 
 fn backend_mask(backend: Option<&'static str>) -> wgpu::Backends {
@@ -300,27 +373,41 @@ pub fn detect(launch: &LaunchConfig, start_attempt: usize) -> Result<RendererSel
 
         let attempt_config = attempt.apply(launch, &mut current);
 
-        let prefer_low_power = attempt.prefers_low_power(launch);
-        match probe_wgpu(
-            attempt_config.backends,
-            prefer_low_power,
-            attempt_config.force_fallback,
-        ) {
-            Ok(info) => {
-                current.backend = format!("{:?}", info.backend);
-                current.adapter_name = Some(info.name.clone());
-                current.adapter_type = Some(format!("{:?}", info.device_type));
-                current.backend_details = Some(format!("Driver: {}", info.driver));
-                if info.device_type == wgpu::DeviceType::Cpu {
+        match attempt_config {
+            AttemptConfig::Wgpu {
+                backends,
+                force_fallback,
+            } => {
+                let prefer_low_power = attempt.prefers_low_power(launch);
+                match probe_wgpu(backends, prefer_low_power, force_fallback) {
+                    Ok(info) => {
+                        current.backend = format!("{:?}", info.backend);
+                        current.adapter_name = Some(info.name.clone());
+                        current.adapter_type = Some(format!("{:?}", info.device_type));
+                        current.backend_details = Some(format!("Driver: {}", info.driver));
+                        if info.device_type == wgpu::DeviceType::Cpu {
+                            current.software_backend = true;
+                        }
+                        if !failures.is_empty() {
+                            current.failure_reason = Some(failures.join(" -> "));
+                        }
+                        return Ok(RendererSelection::new_wgpu(index, attempt.label(), current));
+                    }
+                    Err(err) => {
+                        failures.push(format!("{}: {}", attempt.label(), err));
+                    }
+                }
+            }
+            AttemptConfig::Glow { software } => {
+                current.backend = String::from("glow");
+                current.backend_details = Some("Renderer: eframe glow".to_string());
+                if software {
                     current.software_backend = true;
                 }
                 if !failures.is_empty() {
                     current.failure_reason = Some(failures.join(" -> "));
                 }
-                return Ok(RendererSelection::new_wgpu(index, attempt.label(), current));
-            }
-            Err(err) => {
-                failures.push(format!("{}: {}", attempt.label(), err));
+                return Ok(RendererSelection::new_glow(index, attempt.label(), current));
             }
         }
     }
@@ -357,6 +444,17 @@ fn probe_wgpu(
         backends
     };
 
+    let effective_force_fallback = if cfg!(target_os = "windows") {
+        force_fallback_adapter
+    } else {
+        // `force_fallback_adapter` currently only has effect on Windows where wgpu
+        // can surface the D3D WARP adapter. Requesting it on other platforms causes
+        // `request_adapter` to return `None`, preventing our software GL fallback
+        // (llvmpipe/Zink) from being discovered. Disable it so Linux/BSD builds can
+        // still enumerate software adapters exposed through Mesa.
+        false
+    };
+
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: requested_backends,
         dx12_shader_compiler: Default::default(),
@@ -371,7 +469,7 @@ fn probe_wgpu(
 
     let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference,
-        force_fallback_adapter,
+        force_fallback_adapter: effective_force_fallback,
         compatible_surface: None,
     }))
     .ok_or_else(|| "No compatible GPU adapters".to_string())?;


### PR DESCRIPTION
## Summary
- add an `eframe::Renderer::Glow` fallback attempt so the GUI can boot on systems without exposed wgpu adapters
- enable the `glow` feature in eframe, update the App trait signature, and respect the selected renderer when launching the window
- document the expanded renderer cascade and regenerate the lockfile for the new OpenGL dependencies

## Testing
- cargo test --manifest-path gui/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68d22924634c832ba52d6fdca44968a3