### PR TITLE
Fix glow fallback hardware acceleration request

### DIFF
--- a/gui/src/renderer.rs
+++ b/gui/src/renderer.rs
@@ -41,11 +41,15 @@ impl RendererSelection {
         diagnostics.backend = String::from("glow");
         let mut options = eframe::NativeOptions::default();
         options.renderer = eframe::Renderer::Glow;
-        if diagnostics.software_backend {
-            options.hardware_acceleration = eframe::HardwareAcceleration::Off;
-        } else {
-            options.hardware_acceleration = eframe::HardwareAcceleration::Preferred;
-        }
+        // eframe's glow backend ultimately relies on the platform OpenGL loader.
+        // Requesting "software" acceleration through winit frequently prevents a
+        // context from being created on systems that only expose llvmpipe/OSMesa
+        // fallbacks. We instead rely on the environment variables configured by
+        // the launch attempts (e.g. `LIBGL_ALWAYS_SOFTWARE=1`) to steer Mesa onto
+        // a CPU renderer while keeping the context creation path compatible with
+        // more drivers. As a result we always prefer hardware acceleration here
+        // and let the driver honour the software override when present.
+        options.hardware_acceleration = eframe::HardwareAcceleration::Preferred;
         Self {
             attempt,
             attempt_label,


### PR DESCRIPTION
## Summary
- keep the glow fallback using preferred hardware acceleration so Mesa/llvmpipe contexts can initialise
- document why the launcher now relies on LIBGL_ALWAYS_SOFTWARE for CPU rendering instead of winit's software hint

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d23f77ed08832b8941498db097057a